### PR TITLE
feat: platform admin tenant management (#18)

### DIFF
--- a/src/lib/platform-admin.ts
+++ b/src/lib/platform-admin.ts
@@ -1,0 +1,106 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { count, eq } from "drizzle-orm";
+import { db } from "#/db/index.ts";
+import { tenants, users, plans } from "#/db/schema/index.ts";
+import { auth } from "./auth.ts";
+
+async function requirePlatformAdmin() {
+  const request = getRequest();
+  const session = await auth.api.getSession({ headers: request.headers });
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  const user = session.user as { id: string; role?: string };
+  if (user.role !== "platform_admin") {
+    throw new Error("Forbidden");
+  }
+
+  return session;
+}
+
+export const listTenantsFn = createServerFn({ method: "GET" }).handler(async () => {
+  await requirePlatformAdmin();
+
+  const allTenants = await db
+    .select({
+      id: tenants.id,
+      name: tenants.name,
+      subdomain: tenants.subdomain,
+      status: tenants.status,
+      createdAt: tenants.createdAt,
+      planName: plans.name,
+    })
+    .from(tenants)
+    .leftJoin(plans, eq(tenants.planId, plans.id))
+    .orderBy(tenants.createdAt);
+
+  // Get student counts per tenant
+  const studentCounts = await db
+    .select({
+      tenantId: users.tenantId,
+      count: count(),
+    })
+    .from(users)
+    .where(eq(users.role, "student"))
+    .groupBy(users.tenantId);
+
+  const countMap = new Map(studentCounts.map((sc) => [sc.tenantId, sc.count]));
+
+  return allTenants.map((t) => ({
+    ...t,
+    studentCount: countMap.get(t.id) ?? 0,
+  }));
+});
+
+export const getTenantDetailFn = createServerFn({ method: "GET" })
+  .inputValidator((input: { tenantId: string }) => input)
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const tenant = await db.query.tenants.findFirst({
+      where: eq(tenants.id, data.tenantId),
+    });
+
+    if (!tenant) {
+      throw new Error("Tenant not found");
+    }
+
+    const plan = tenant.planId
+      ? await db.query.plans.findFirst({ where: eq(plans.id, tenant.planId) })
+      : null;
+
+    const [studentCountResult] = await db
+      .select({ count: count() })
+      .from(users)
+      .where(eq(users.tenantId, tenant.id));
+
+    return {
+      ...tenant,
+      plan,
+      userCount: studentCountResult?.count ?? 0,
+    };
+  });
+
+export const updateTenantStatusFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (input: { tenantId: string; status: "active" | "suspended" | "inactive" }) => input,
+  )
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const tenant = await db.query.tenants.findFirst({
+      where: eq(tenants.id, data.tenantId),
+      columns: { id: true },
+    });
+
+    if (!tenant) {
+      return { error: "Tenant not found" };
+    }
+
+    await db.update(tenants).set({ status: data.status }).where(eq(tenants.id, data.tenantId));
+
+    return { error: null };
+  });

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,306 +8,375 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as VerifyEmailRouteImport } from './routes/verify-email'
-import { Route as ResetPasswordRouteImport } from './routes/reset-password'
-import { Route as RegisterRouteImport } from './routes/register'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
-import { Route as CreateSchoolRouteImport } from './routes/create-school'
-import { Route as AboutRouteImport } from './routes/about'
-import { Route as AdminRouteRouteImport } from './routes/admin/route'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as AdminIndexRouteImport } from './routes/admin/index'
-import { Route as AdminOnboardingRouteImport } from './routes/admin/onboarding'
-import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
-import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as VerifyEmailRouteImport } from "./routes/verify-email";
+import { Route as ResetPasswordRouteImport } from "./routes/reset-password";
+import { Route as RegisterRouteImport } from "./routes/register";
+import { Route as LoginRouteImport } from "./routes/login";
+import { Route as ForgotPasswordRouteImport } from "./routes/forgot-password";
+import { Route as CreateSchoolRouteImport } from "./routes/create-school";
+import { Route as AboutRouteImport } from "./routes/about";
+import { Route as PlatformAdminRouteRouteImport } from "./routes/platform-admin/route";
+import { Route as AdminRouteRouteImport } from "./routes/admin/route";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as PlatformAdminIndexRouteImport } from "./routes/platform-admin/index";
+import { Route as AdminIndexRouteImport } from "./routes/admin/index";
+import { Route as AdminOnboardingRouteImport } from "./routes/admin/onboarding";
+import { Route as PlatformAdminTenantsTenantIdRouteImport } from "./routes/platform-admin/tenants/$tenantId";
+import { Route as ApiWebhooksStripeRouteImport } from "./routes/api/webhooks/stripe";
+import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
 
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
-  id: '/verify-email',
-  path: '/verify-email',
+  id: "/verify-email",
+  path: "/verify-email",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
-  id: '/reset-password',
-  path: '/reset-password',
+  id: "/reset-password",
+  path: "/reset-password",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const RegisterRoute = RegisterRouteImport.update({
-  id: '/register',
-  path: '/register',
+  id: "/register",
+  path: "/register",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
+  id: "/login",
+  path: "/login",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
-  id: '/forgot-password',
-  path: '/forgot-password',
+  id: "/forgot-password",
+  path: "/forgot-password",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const CreateSchoolRoute = CreateSchoolRouteImport.update({
-  id: '/create-school',
-  path: '/create-school',
+  id: "/create-school",
+  path: "/create-school",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AboutRoute = AboutRouteImport.update({
-  id: '/about',
-  path: '/about',
+  id: "/about",
+  path: "/about",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const PlatformAdminRouteRoute = PlatformAdminRouteRouteImport.update({
+  id: "/platform-admin",
+  path: "/platform-admin",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const AdminRouteRoute = AdminRouteRouteImport.update({
-  id: '/admin',
-  path: '/admin',
+  id: "/admin",
+  path: "/admin",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const PlatformAdminIndexRoute = PlatformAdminIndexRouteImport.update({
+  id: "/",
+  path: "/",
+  getParentRoute: () => PlatformAdminRouteRoute,
+} as any);
 const AdminIndexRoute = AdminIndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => AdminRouteRoute,
-} as any)
+} as any);
 const AdminOnboardingRoute = AdminOnboardingRouteImport.update({
-  id: '/onboarding',
-  path: '/onboarding',
+  id: "/onboarding",
+  path: "/onboarding",
   getParentRoute: () => AdminRouteRoute,
-} as any)
+} as any);
+const PlatformAdminTenantsTenantIdRoute = PlatformAdminTenantsTenantIdRouteImport.update({
+  id: "/tenants/$tenantId",
+  path: "/tenants/$tenantId",
+  getParentRoute: () => PlatformAdminRouteRoute,
+} as any);
 const ApiWebhooksStripeRoute = ApiWebhooksStripeRouteImport.update({
-  id: '/api/webhooks/stripe',
-  path: '/api/webhooks/stripe',
+  id: "/api/webhooks/stripe",
+  path: "/api/webhooks/stripe",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-  id: '/api/auth/$',
-  path: '/api/auth/$',
+  id: "/api/auth/$",
+  path: "/api/auth/$",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRouteWithChildren
-  '/about': typeof AboutRoute
-  '/create-school': typeof CreateSchoolRoute
-  '/forgot-password': typeof ForgotPasswordRoute
-  '/login': typeof LoginRoute
-  '/register': typeof RegisterRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/verify-email': typeof VerifyEmailRoute
-  '/admin/onboarding': typeof AdminOnboardingRoute
-  '/admin/': typeof AdminIndexRoute
-  '/api/auth/$': typeof ApiAuthSplatRoute
-  '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
+  "/": typeof IndexRoute;
+  "/admin": typeof AdminRouteRouteWithChildren;
+  "/platform-admin": typeof PlatformAdminRouteRouteWithChildren;
+  "/about": typeof AboutRoute;
+  "/create-school": typeof CreateSchoolRoute;
+  "/forgot-password": typeof ForgotPasswordRoute;
+  "/login": typeof LoginRoute;
+  "/register": typeof RegisterRoute;
+  "/reset-password": typeof ResetPasswordRoute;
+  "/verify-email": typeof VerifyEmailRoute;
+  "/admin/onboarding": typeof AdminOnboardingRoute;
+  "/admin/": typeof AdminIndexRoute;
+  "/platform-admin/": typeof PlatformAdminIndexRoute;
+  "/api/auth/$": typeof ApiAuthSplatRoute;
+  "/api/webhooks/stripe": typeof ApiWebhooksStripeRoute;
+  "/platform-admin/tenants/$tenantId": typeof PlatformAdminTenantsTenantIdRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/about': typeof AboutRoute
-  '/create-school': typeof CreateSchoolRoute
-  '/forgot-password': typeof ForgotPasswordRoute
-  '/login': typeof LoginRoute
-  '/register': typeof RegisterRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/verify-email': typeof VerifyEmailRoute
-  '/admin/onboarding': typeof AdminOnboardingRoute
-  '/admin': typeof AdminIndexRoute
-  '/api/auth/$': typeof ApiAuthSplatRoute
-  '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
+  "/": typeof IndexRoute;
+  "/about": typeof AboutRoute;
+  "/create-school": typeof CreateSchoolRoute;
+  "/forgot-password": typeof ForgotPasswordRoute;
+  "/login": typeof LoginRoute;
+  "/register": typeof RegisterRoute;
+  "/reset-password": typeof ResetPasswordRoute;
+  "/verify-email": typeof VerifyEmailRoute;
+  "/admin/onboarding": typeof AdminOnboardingRoute;
+  "/admin": typeof AdminIndexRoute;
+  "/platform-admin": typeof PlatformAdminIndexRoute;
+  "/api/auth/$": typeof ApiAuthSplatRoute;
+  "/api/webhooks/stripe": typeof ApiWebhooksStripeRoute;
+  "/platform-admin/tenants/$tenantId": typeof PlatformAdminTenantsTenantIdRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRouteWithChildren
-  '/about': typeof AboutRoute
-  '/create-school': typeof CreateSchoolRoute
-  '/forgot-password': typeof ForgotPasswordRoute
-  '/login': typeof LoginRoute
-  '/register': typeof RegisterRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/verify-email': typeof VerifyEmailRoute
-  '/admin/onboarding': typeof AdminOnboardingRoute
-  '/admin/': typeof AdminIndexRoute
-  '/api/auth/$': typeof ApiAuthSplatRoute
-  '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/admin": typeof AdminRouteRouteWithChildren;
+  "/platform-admin": typeof PlatformAdminRouteRouteWithChildren;
+  "/about": typeof AboutRoute;
+  "/create-school": typeof CreateSchoolRoute;
+  "/forgot-password": typeof ForgotPasswordRoute;
+  "/login": typeof LoginRoute;
+  "/register": typeof RegisterRoute;
+  "/reset-password": typeof ResetPasswordRoute;
+  "/verify-email": typeof VerifyEmailRoute;
+  "/admin/onboarding": typeof AdminOnboardingRoute;
+  "/admin/": typeof AdminIndexRoute;
+  "/platform-admin/": typeof PlatformAdminIndexRoute;
+  "/api/auth/$": typeof ApiAuthSplatRoute;
+  "/api/webhooks/stripe": typeof ApiWebhooksStripeRoute;
+  "/platform-admin/tenants/$tenantId": typeof PlatformAdminTenantsTenantIdRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/admin'
-    | '/about'
-    | '/create-school'
-    | '/forgot-password'
-    | '/login'
-    | '/register'
-    | '/reset-password'
-    | '/verify-email'
-    | '/admin/onboarding'
-    | '/admin/'
-    | '/api/auth/$'
-    | '/api/webhooks/stripe'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/admin"
+    | "/platform-admin"
+    | "/about"
+    | "/create-school"
+    | "/forgot-password"
+    | "/login"
+    | "/register"
+    | "/reset-password"
+    | "/verify-email"
+    | "/admin/onboarding"
+    | "/admin/"
+    | "/platform-admin/"
+    | "/api/auth/$"
+    | "/api/webhooks/stripe"
+    | "/platform-admin/tenants/$tenantId";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/about'
-    | '/create-school'
-    | '/forgot-password'
-    | '/login'
-    | '/register'
-    | '/reset-password'
-    | '/verify-email'
-    | '/admin/onboarding'
-    | '/admin'
-    | '/api/auth/$'
-    | '/api/webhooks/stripe'
+    | "/"
+    | "/about"
+    | "/create-school"
+    | "/forgot-password"
+    | "/login"
+    | "/register"
+    | "/reset-password"
+    | "/verify-email"
+    | "/admin/onboarding"
+    | "/admin"
+    | "/platform-admin"
+    | "/api/auth/$"
+    | "/api/webhooks/stripe"
+    | "/platform-admin/tenants/$tenantId";
   id:
-    | '__root__'
-    | '/'
-    | '/admin'
-    | '/about'
-    | '/create-school'
-    | '/forgot-password'
-    | '/login'
-    | '/register'
-    | '/reset-password'
-    | '/verify-email'
-    | '/admin/onboarding'
-    | '/admin/'
-    | '/api/auth/$'
-    | '/api/webhooks/stripe'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/admin"
+    | "/platform-admin"
+    | "/about"
+    | "/create-school"
+    | "/forgot-password"
+    | "/login"
+    | "/register"
+    | "/reset-password"
+    | "/verify-email"
+    | "/admin/onboarding"
+    | "/admin/"
+    | "/platform-admin/"
+    | "/api/auth/$"
+    | "/api/webhooks/stripe"
+    | "/platform-admin/tenants/$tenantId";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  AdminRouteRoute: typeof AdminRouteRouteWithChildren
-  AboutRoute: typeof AboutRoute
-  CreateSchoolRoute: typeof CreateSchoolRoute
-  ForgotPasswordRoute: typeof ForgotPasswordRoute
-  LoginRoute: typeof LoginRoute
-  RegisterRoute: typeof RegisterRoute
-  ResetPasswordRoute: typeof ResetPasswordRoute
-  VerifyEmailRoute: typeof VerifyEmailRoute
-  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
-  ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
+  IndexRoute: typeof IndexRoute;
+  AdminRouteRoute: typeof AdminRouteRouteWithChildren;
+  PlatformAdminRouteRoute: typeof PlatformAdminRouteRouteWithChildren;
+  AboutRoute: typeof AboutRoute;
+  CreateSchoolRoute: typeof CreateSchoolRoute;
+  ForgotPasswordRoute: typeof ForgotPasswordRoute;
+  LoginRoute: typeof LoginRoute;
+  RegisterRoute: typeof RegisterRoute;
+  ResetPasswordRoute: typeof ResetPasswordRoute;
+  VerifyEmailRoute: typeof VerifyEmailRoute;
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
+  ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/verify-email': {
-      id: '/verify-email'
-      path: '/verify-email'
-      fullPath: '/verify-email'
-      preLoaderRoute: typeof VerifyEmailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/reset-password': {
-      id: '/reset-password'
-      path: '/reset-password'
-      fullPath: '/reset-password'
-      preLoaderRoute: typeof ResetPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/register': {
-      id: '/register'
-      path: '/register'
-      fullPath: '/register'
-      preLoaderRoute: typeof RegisterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/forgot-password': {
-      id: '/forgot-password'
-      path: '/forgot-password'
-      fullPath: '/forgot-password'
-      preLoaderRoute: typeof ForgotPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/create-school': {
-      id: '/create-school'
-      path: '/create-school'
-      fullPath: '/create-school'
-      preLoaderRoute: typeof CreateSchoolRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/admin': {
-      id: '/admin'
-      path: '/admin'
-      fullPath: '/admin'
-      preLoaderRoute: typeof AdminRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/admin/': {
-      id: '/admin/'
-      path: '/'
-      fullPath: '/admin/'
-      preLoaderRoute: typeof AdminIndexRouteImport
-      parentRoute: typeof AdminRouteRoute
-    }
-    '/admin/onboarding': {
-      id: '/admin/onboarding'
-      path: '/onboarding'
-      fullPath: '/admin/onboarding'
-      preLoaderRoute: typeof AdminOnboardingRouteImport
-      parentRoute: typeof AdminRouteRoute
-    }
-    '/api/webhooks/stripe': {
-      id: '/api/webhooks/stripe'
-      path: '/api/webhooks/stripe'
-      fullPath: '/api/webhooks/stripe'
-      preLoaderRoute: typeof ApiWebhooksStripeRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/auth/$': {
-      id: '/api/auth/$'
-      path: '/api/auth/$'
-      fullPath: '/api/auth/$'
-      preLoaderRoute: typeof ApiAuthSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/verify-email": {
+      id: "/verify-email";
+      path: "/verify-email";
+      fullPath: "/verify-email";
+      preLoaderRoute: typeof VerifyEmailRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/reset-password": {
+      id: "/reset-password";
+      path: "/reset-password";
+      fullPath: "/reset-password";
+      preLoaderRoute: typeof ResetPasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/register": {
+      id: "/register";
+      path: "/register";
+      fullPath: "/register";
+      preLoaderRoute: typeof RegisterRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/login": {
+      id: "/login";
+      path: "/login";
+      fullPath: "/login";
+      preLoaderRoute: typeof LoginRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/forgot-password": {
+      id: "/forgot-password";
+      path: "/forgot-password";
+      fullPath: "/forgot-password";
+      preLoaderRoute: typeof ForgotPasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/create-school": {
+      id: "/create-school";
+      path: "/create-school";
+      fullPath: "/create-school";
+      preLoaderRoute: typeof CreateSchoolRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/about": {
+      id: "/about";
+      path: "/about";
+      fullPath: "/about";
+      preLoaderRoute: typeof AboutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/platform-admin": {
+      id: "/platform-admin";
+      path: "/platform-admin";
+      fullPath: "/platform-admin";
+      preLoaderRoute: typeof PlatformAdminRouteRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/admin": {
+      id: "/admin";
+      path: "/admin";
+      fullPath: "/admin";
+      preLoaderRoute: typeof AdminRouteRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/platform-admin/": {
+      id: "/platform-admin/";
+      path: "/";
+      fullPath: "/platform-admin/";
+      preLoaderRoute: typeof PlatformAdminIndexRouteImport;
+      parentRoute: typeof PlatformAdminRouteRoute;
+    };
+    "/admin/": {
+      id: "/admin/";
+      path: "/";
+      fullPath: "/admin/";
+      preLoaderRoute: typeof AdminIndexRouteImport;
+      parentRoute: typeof AdminRouteRoute;
+    };
+    "/admin/onboarding": {
+      id: "/admin/onboarding";
+      path: "/onboarding";
+      fullPath: "/admin/onboarding";
+      preLoaderRoute: typeof AdminOnboardingRouteImport;
+      parentRoute: typeof AdminRouteRoute;
+    };
+    "/platform-admin/tenants/$tenantId": {
+      id: "/platform-admin/tenants/$tenantId";
+      path: "/tenants/$tenantId";
+      fullPath: "/platform-admin/tenants/$tenantId";
+      preLoaderRoute: typeof PlatformAdminTenantsTenantIdRouteImport;
+      parentRoute: typeof PlatformAdminRouteRoute;
+    };
+    "/api/webhooks/stripe": {
+      id: "/api/webhooks/stripe";
+      path: "/api/webhooks/stripe";
+      fullPath: "/api/webhooks/stripe";
+      preLoaderRoute: typeof ApiWebhooksStripeRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/api/auth/$": {
+      id: "/api/auth/$";
+      path: "/api/auth/$";
+      fullPath: "/api/auth/$";
+      preLoaderRoute: typeof ApiAuthSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
 interface AdminRouteRouteChildren {
-  AdminOnboardingRoute: typeof AdminOnboardingRoute
-  AdminIndexRoute: typeof AdminIndexRoute
+  AdminOnboardingRoute: typeof AdminOnboardingRoute;
+  AdminIndexRoute: typeof AdminIndexRoute;
 }
 
 const AdminRouteRouteChildren: AdminRouteRouteChildren = {
   AdminOnboardingRoute: AdminOnboardingRoute,
   AdminIndexRoute: AdminIndexRoute,
+};
+
+const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(AdminRouteRouteChildren);
+
+interface PlatformAdminRouteRouteChildren {
+  PlatformAdminIndexRoute: typeof PlatformAdminIndexRoute;
+  PlatformAdminTenantsTenantIdRoute: typeof PlatformAdminTenantsTenantIdRoute;
 }
 
-const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
-  AdminRouteRouteChildren,
-)
+const PlatformAdminRouteRouteChildren: PlatformAdminRouteRouteChildren = {
+  PlatformAdminIndexRoute: PlatformAdminIndexRoute,
+  PlatformAdminTenantsTenantIdRoute: PlatformAdminTenantsTenantIdRoute,
+};
+
+const PlatformAdminRouteRouteWithChildren = PlatformAdminRouteRoute._addFileChildren(
+  PlatformAdminRouteRouteChildren,
+);
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRouteRoute: AdminRouteRouteWithChildren,
+  PlatformAdminRouteRoute: PlatformAdminRouteRouteWithChildren,
   AboutRoute: AboutRoute,
   CreateSchoolRoute: CreateSchoolRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
@@ -317,17 +386,17 @@ const rootRouteChildren: RootRouteChildren = {
   VerifyEmailRoute: VerifyEmailRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
+import type { getRouter } from "./router.tsx";
+import type { startInstance } from "./start.ts";
+declare module "@tanstack/react-start" {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
   }
 }

--- a/src/routes/platform-admin/index.tsx
+++ b/src/routes/platform-admin/index.tsx
@@ -1,0 +1,79 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { listTenantsFn } from "#/lib/platform-admin.ts";
+
+export const Route = createFileRoute("/platform-admin/")({
+  loader: () => listTenantsFn(),
+  component: TenantListPage,
+});
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  suspended: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  inactive: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+};
+
+function TenantListPage() {
+  const tenants = Route.useLoaderData();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Tenant Management</h1>
+        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+          View and manage all tenants on the platform.
+        </p>
+      </div>
+
+      {tenants.length === 0 ? (
+        <p className="text-neutral-500 dark:text-neutral-400">No tenants found.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-neutral-200 dark:border-neutral-800">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
+              <tr>
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Subdomain</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Plan</th>
+                <th className="px-4 py-3 font-medium text-right">Students</th>
+                <th className="px-4 py-3 font-medium">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+              {tenants.map((tenant) => (
+                <tr key={tenant.id} className="bg-white dark:bg-neutral-950">
+                  <td className="px-4 py-3">
+                    <Link
+                      to="/platform-admin/tenants/$tenantId"
+                      params={{ tenantId: tenant.id }}
+                      className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {tenant.name}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
+                    {tenant.subdomain}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[tenant.status] ?? ""}`}
+                    >
+                      {tenant.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
+                    {tenant.planName ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">{tenant.studentCount}</td>
+                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
+                    {new Date(tenant.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes/platform-admin/route.tsx
+++ b/src/routes/platform-admin/route.tsx
@@ -1,0 +1,28 @@
+import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+import { getSessionFn } from "#/lib/auth-session.ts";
+import type { User } from "#/lib/auth.ts";
+
+export const Route = createFileRoute("/platform-admin")({
+  beforeLoad: async () => {
+    const session = await getSessionFn();
+    if (!session) {
+      throw redirect({ to: "/login" });
+    }
+
+    const user = session.user as User;
+    if (user.role !== "platform_admin") {
+      throw redirect({ to: "/" });
+    }
+
+    return { user, session: session.session };
+  },
+  component: PlatformAdminLayout,
+});
+
+function PlatformAdminLayout() {
+  return (
+    <main className="page-wrap py-8">
+      <Outlet />
+    </main>
+  );
+}

--- a/src/routes/platform-admin/tenants/$tenantId.tsx
+++ b/src/routes/platform-admin/tenants/$tenantId.tsx
@@ -1,0 +1,125 @@
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { useState } from "react";
+import { getTenantDetailFn, updateTenantStatusFn } from "#/lib/platform-admin.ts";
+
+export const Route = createFileRoute("/platform-admin/tenants/$tenantId")({
+  loader: ({ params }) => getTenantDetailFn({ data: { tenantId: params.tenantId } }),
+  component: TenantDetailPage,
+});
+
+const STATUS_OPTIONS = ["active", "suspended", "inactive"] as const;
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  suspended: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  inactive: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+};
+
+function TenantDetailPage() {
+  const tenant = Route.useLoaderData();
+  const router = useRouter();
+  const [status, setStatus] = useState(tenant.status);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const hasChanged = status !== tenant.status;
+
+  async function handleSave() {
+    setSaving(true);
+    setMessage(null);
+    const result = await updateTenantStatusFn({
+      data: { tenantId: tenant.id, status },
+    });
+    setSaving(false);
+
+    if (result.error) {
+      setMessage(result.error);
+    } else {
+      setMessage("Status updated successfully.");
+      router.invalidate();
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          to="/platform-admin"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          &larr; Back to tenants
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">{tenant.name}</h1>
+        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">{tenant.subdomain}</p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <InfoCard label="Status">
+          <span
+            className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[tenant.status] ?? ""}`}
+          >
+            {tenant.status}
+          </span>
+        </InfoCard>
+        <InfoCard label="Plan">{tenant.plan?.name ?? "None"}</InfoCard>
+        <InfoCard label="Users">{tenant.userCount}</InfoCard>
+        <InfoCard label="Created">{new Date(tenant.createdAt).toLocaleDateString()}</InfoCard>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <InfoCard label="Stripe Connect">
+          {tenant.stripeConnectAccountId ?? "Not connected"}
+        </InfoCard>
+        <InfoCard label="Stripe Onboarding">
+          {tenant.stripeOnboardingComplete === "true" ? "Complete" : "Incomplete"}
+        </InfoCard>
+      </div>
+
+      <div className="rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h2 className="text-lg font-semibold">Modify Status</h2>
+        <div className="mt-4 flex items-end gap-4">
+          <div>
+            <label
+              htmlFor="status-select"
+              className="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+            >
+              Status
+            </label>
+            <select
+              id="status-select"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as typeof status)}
+              className="mt-1 rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!hasChanged || saving}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+        {message && (
+          <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">{message}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function InfoCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400">{label}</p>
+      <div className="mt-1 text-sm font-semibold">{children}</div>
+    </div>
+  );
+}

--- a/tests/platform-admin.test.ts
+++ b/tests/platform-admin.test.ts
@@ -1,0 +1,323 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { count, eq } from "drizzle-orm";
+import { db } from "#/db/index.ts";
+import { tenants, users, accounts, sessions, plans } from "#/db/schema/index.ts";
+
+vi.mock("#/lib/email.ts", () => ({
+  sendEmail: vi.fn().mockResolvedValue({ id: "mock-email-id" }),
+}));
+
+describe("platform admin: tenant management", () => {
+  const timestamp = Date.now();
+  const platformTenantSubdomain = `pa-platform-${timestamp}`;
+  const tenantASubdomain = `pa-school-a-${timestamp}`;
+  const tenantBSubdomain = `pa-school-b-${timestamp}`;
+  let platformTenantId: string;
+  let tenantAId: string;
+  let tenantBId: string;
+  let platformAdminId: string;
+  let studentUserId: string;
+  let tenantOwnerUserId: string;
+  let testPlanId: string;
+
+  beforeAll(async () => {
+    // Create a plan for testing
+    const [plan] = await db
+      .insert(plans)
+      .values({ name: "Pro Plan", maxCourses: 10, maxStudents: 100 })
+      .returning();
+    testPlanId = plan.id;
+
+    // Create platform tenant (where the platform admin user lives)
+    const [platformTenant] = await db
+      .insert(tenants)
+      .values({ name: "Platform", subdomain: platformTenantSubdomain })
+      .returning();
+    platformTenantId = platformTenant.id;
+
+    // Create school tenants
+    const [tenantA] = await db
+      .insert(tenants)
+      .values({ name: "School Alpha", subdomain: tenantASubdomain, planId: testPlanId })
+      .returning();
+    tenantAId = tenantA.id;
+
+    const [tenantB] = await db
+      .insert(tenants)
+      .values({ name: "School Beta", subdomain: tenantBSubdomain, status: "suspended" })
+      .returning();
+    tenantBId = tenantB.id;
+
+    // Create a platform_admin user
+    const [adminUser] = await db
+      .insert(users)
+      .values({
+        name: "Platform Admin",
+        email: `padmin-${timestamp}@test.com`,
+        tenantId: platformTenantId,
+        role: "platform_admin",
+      })
+      .returning();
+    platformAdminId = adminUser.id;
+
+    // Create a student user on tenant A
+    const [student] = await db
+      .insert(users)
+      .values({
+        name: "Student One",
+        email: `student1-${timestamp}@test.com`,
+        tenantId: tenantAId,
+        role: "student",
+      })
+      .returning();
+    studentUserId = student.id;
+
+    // Create a tenant_owner on tenant A
+    const [owner] = await db
+      .insert(users)
+      .values({
+        name: "Owner One",
+        email: `owner1-${timestamp}@test.com`,
+        tenantId: tenantAId,
+        role: "tenant_owner",
+      })
+      .returning();
+    tenantOwnerUserId = owner.id;
+
+    // Create another student on tenant A for count testing
+    await db.insert(users).values({
+      name: "Student Two",
+      email: `student2-${timestamp}@test.com`,
+      tenantId: tenantAId,
+      role: "student",
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up users and their sessions/accounts
+    const allTenantIds = [platformTenantId, tenantAId, tenantBId];
+    const allUsers: { id: string }[] = [];
+
+    for (const tid of allTenantIds) {
+      const tusers = await db.query.users.findMany({
+        where: eq(users.tenantId, tid),
+        columns: { id: true },
+      });
+      allUsers.push(...tusers);
+    }
+
+    for (const u of allUsers) {
+      await db.delete(sessions).where(eq(sessions.userId, u.id));
+      await db.delete(accounts).where(eq(accounts.userId, u.id));
+    }
+    for (const u of allUsers) {
+      await db.delete(users).where(eq(users.id, u.id));
+    }
+
+    // Delete tenants
+    await db.delete(tenants).where(eq(tenants.id, tenantAId));
+    await db.delete(tenants).where(eq(tenants.id, tenantBId));
+    await db.delete(tenants).where(eq(tenants.id, platformTenantId));
+
+    // Delete plan
+    await db.delete(plans).where(eq(plans.id, testPlanId));
+  });
+
+  describe("access control", () => {
+    it("platform_admin role exists and is distinct from tenant roles", async () => {
+      const admin = await db.query.users.findFirst({
+        where: eq(users.id, platformAdminId),
+      });
+      expect(admin).toBeDefined();
+      expect(admin!.role).toBe("platform_admin");
+    });
+
+    it("student users do not have platform_admin role", async () => {
+      const student = await db.query.users.findFirst({
+        where: eq(users.id, studentUserId),
+      });
+      expect(student).toBeDefined();
+      expect(student!.role).toBe("student");
+      expect(student!.role).not.toBe("platform_admin");
+    });
+
+    it("tenant_owner users do not have platform_admin role", async () => {
+      const owner = await db.query.users.findFirst({
+        where: eq(users.id, tenantOwnerUserId),
+      });
+      expect(owner).toBeDefined();
+      expect(owner!.role).toBe("tenant_owner");
+      expect(owner!.role).not.toBe("platform_admin");
+    });
+
+    it("platform_admin role check correctly identifies authorized users", () => {
+      const isAdmin = (role: string) => role === "platform_admin";
+
+      expect(isAdmin("platform_admin")).toBe(true);
+      expect(isAdmin("tenant_owner")).toBe(false);
+      expect(isAdmin("tenant_admin")).toBe(false);
+      expect(isAdmin("student")).toBe(false);
+    });
+  });
+
+  describe("tenant listing", () => {
+    it("lists all tenants with their status", async () => {
+      const result = await db
+        .select({
+          id: tenants.id,
+          name: tenants.name,
+          subdomain: tenants.subdomain,
+          status: tenants.status,
+          createdAt: tenants.createdAt,
+        })
+        .from(tenants)
+        .orderBy(tenants.createdAt);
+
+      // Our test tenants should be in the results
+      const ourTenants = result.filter((t) =>
+        [platformTenantId, tenantAId, tenantBId].includes(t.id),
+      );
+      expect(ourTenants.length).toBe(3);
+
+      const schoolA = ourTenants.find((t) => t.id === tenantAId);
+      expect(schoolA).toBeDefined();
+      expect(schoolA!.name).toBe("School Alpha");
+      expect(schoolA!.status).toBe("active");
+
+      const schoolB = ourTenants.find((t) => t.id === tenantBId);
+      expect(schoolB).toBeDefined();
+      expect(schoolB!.name).toBe("School Beta");
+      expect(schoolB!.status).toBe("suspended");
+    });
+
+    it("includes plan information via join", async () => {
+      const result = await db
+        .select({
+          id: tenants.id,
+          name: tenants.name,
+          planName: plans.name,
+        })
+        .from(tenants)
+        .leftJoin(plans, eq(tenants.planId, plans.id));
+
+      const schoolA = result.find((t) => t.id === tenantAId);
+      expect(schoolA).toBeDefined();
+      expect(schoolA!.planName).toBe("Pro Plan");
+
+      const schoolB = result.find((t) => t.id === tenantBId);
+      expect(schoolB).toBeDefined();
+      expect(schoolB!.planName).toBeNull();
+    });
+
+    it("computes student count per tenant", async () => {
+      const studentCounts = await db
+        .select({
+          tenantId: users.tenantId,
+          count: count(),
+        })
+        .from(users)
+        .where(eq(users.role, "student"))
+        .groupBy(users.tenantId);
+
+      const tenantACount = studentCounts.find((sc) => sc.tenantId === tenantAId);
+      expect(tenantACount).toBeDefined();
+      expect(tenantACount!.count).toBe(2);
+
+      // Tenant B has no students
+      const tenantBCount = studentCounts.find((sc) => sc.tenantId === tenantBId);
+      expect(tenantBCount).toBeUndefined();
+    });
+
+    it("includes creation date for each tenant", async () => {
+      const result = await db.query.tenants.findFirst({
+        where: eq(tenants.id, tenantAId),
+      });
+      expect(result).toBeDefined();
+      expect(result!.createdAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("tenant status modification", () => {
+    it("updates tenant status from active to suspended", async () => {
+      // Create a temporary tenant for modification testing
+      const subdomain = `pa-mod-${timestamp}`;
+      const [tenant] = await db
+        .insert(tenants)
+        .values({ name: "Mod School", subdomain })
+        .returning();
+
+      expect(tenant.status).toBe("active");
+
+      await db.update(tenants).set({ status: "suspended" }).where(eq(tenants.id, tenant.id));
+
+      const updated = await db.query.tenants.findFirst({
+        where: eq(tenants.id, tenant.id),
+      });
+      expect(updated!.status).toBe("suspended");
+
+      // Clean up
+      await db.delete(tenants).where(eq(tenants.id, tenant.id));
+    });
+
+    it("updates tenant status from suspended to inactive", async () => {
+      const subdomain = `pa-mod2-${timestamp}`;
+      const [tenant] = await db
+        .insert(tenants)
+        .values({ name: "Mod School 2", subdomain, status: "suspended" })
+        .returning();
+
+      expect(tenant.status).toBe("suspended");
+
+      await db.update(tenants).set({ status: "inactive" }).where(eq(tenants.id, tenant.id));
+
+      const updated = await db.query.tenants.findFirst({
+        where: eq(tenants.id, tenant.id),
+      });
+      expect(updated!.status).toBe("inactive");
+
+      // Clean up
+      await db.delete(tenants).where(eq(tenants.id, tenant.id));
+    });
+
+    it("updates tenant status from inactive back to active", async () => {
+      const subdomain = `pa-mod3-${timestamp}`;
+      const [tenant] = await db
+        .insert(tenants)
+        .values({ name: "Mod School 3", subdomain, status: "inactive" })
+        .returning();
+
+      expect(tenant.status).toBe("inactive");
+
+      await db.update(tenants).set({ status: "active" }).where(eq(tenants.id, tenant.id));
+
+      const updated = await db.query.tenants.findFirst({
+        where: eq(tenants.id, tenant.id),
+      });
+      expect(updated!.status).toBe("active");
+
+      // Clean up
+      await db.delete(tenants).where(eq(tenants.id, tenant.id));
+    });
+
+    it("does not modify other tenant fields when updating status", async () => {
+      const subdomain = `pa-mod4-${timestamp}`;
+      const [tenant] = await db
+        .insert(tenants)
+        .values({ name: "Keep Fields School", subdomain, planId: testPlanId })
+        .returning();
+
+      await db.update(tenants).set({ status: "suspended" }).where(eq(tenants.id, tenant.id));
+
+      const updated = await db.query.tenants.findFirst({
+        where: eq(tenants.id, tenant.id),
+      });
+      expect(updated!.name).toBe("Keep Fields School");
+      expect(updated!.subdomain).toBe(subdomain);
+      expect(updated!.planId).toBe(testPlanId);
+      expect(updated!.status).toBe("suspended");
+
+      // Clean up
+      await db.delete(tenants).where(eq(tenants.id, tenant.id));
+    });
+  });
+});


### PR DESCRIPTION
Add platform-level admin interface for viewing and managing tenants,
restricted to users with the platform_admin role.

- Server functions: list tenants (with plan/student count), get detail, update status
- Routes: /platform-admin with platform_admin-only guard, tenant list, tenant detail
- Tests: access control, listing with joins, status modification

https://claude.ai/code/session_01FzzsPVXjmi2bMwm9ahy58y