### PR TITLE
feat: module/lesson reordering with up/down controls

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -271,6 +271,53 @@ export const deleteModuleFn = createServerFn({ method: "POST" })
     return { success: true };
   });
 
+export const reorderModulesFn = createServerFn({ method: "POST" })
+  .inputValidator((input: { courseId: string; moduleIds: string[] }) => input)
+  .handler(async ({ data }) => {
+    const user = await requireInstructor();
+
+    // Verify course ownership
+    const course = await db.query.courses.findFirst({
+      where: and(eq(courses.id, data.courseId), eq(courses.tenantId, user.tenantId)),
+      columns: { id: true },
+    });
+    if (!course) throw new Error("Course not found");
+
+    if (data.moduleIds.length === 0) return [];
+
+    // Verify all modules belong to this course and that the input
+    // represents the complete set (no partial reorders that would leave
+    // gaps or phantom entries)
+    const existing = await db.query.modules.findMany({
+      where: eq(modules.courseId, data.courseId),
+      columns: { id: true },
+    });
+
+    if (existing.length !== data.moduleIds.length) {
+      throw new Error("Module list does not match course modules");
+    }
+    const existingIds = new Set(existing.map((m) => m.id));
+    for (const id of data.moduleIds) {
+      if (!existingIds.has(id)) {
+        throw new Error("Module list does not match course modules");
+      }
+    }
+
+    // Atomic update: set each module's position to its index in the list
+    const reordered = await db.transaction(async (tx) => {
+      for (let i = 0; i < data.moduleIds.length; i++) {
+        await tx.update(modules).set({ position: i }).where(eq(modules.id, data.moduleIds[i]));
+      }
+
+      return tx.query.modules.findMany({
+        where: eq(modules.courseId, data.courseId),
+        orderBy: [asc(modules.position)],
+      });
+    });
+
+    return reordered;
+  });
+
 // ── Lessons ──────────────────────────────────────────────────────────
 
 export const listLessonsFn = createServerFn({ method: "GET" })
@@ -414,4 +461,55 @@ export const deleteLessonFn = createServerFn({ method: "POST" })
 
     await db.delete(lessons).where(eq(lessons.id, data.lessonId));
     return { success: true };
+  });
+
+export const reorderLessonsFn = createServerFn({ method: "POST" })
+  .inputValidator((input: { moduleId: string; lessonIds: string[] }) => input)
+  .handler(async ({ data }) => {
+    const user = await requireInstructor();
+
+    // Verify module → course → tenant chain
+    const mod = await db.query.modules.findFirst({
+      where: eq(modules.id, data.moduleId),
+    });
+    if (!mod) throw new Error("Module not found");
+
+    const course = await db.query.courses.findFirst({
+      where: and(eq(courses.id, mod.courseId), eq(courses.tenantId, user.tenantId)),
+      columns: { id: true },
+    });
+    if (!course) throw new Error("Module not found");
+
+    if (data.lessonIds.length === 0) return [];
+
+    // Verify all lessons belong to this module and that the input
+    // represents the complete set
+    const existing = await db.query.lessons.findMany({
+      where: eq(lessons.moduleId, data.moduleId),
+      columns: { id: true },
+    });
+
+    if (existing.length !== data.lessonIds.length) {
+      throw new Error("Lesson list does not match module lessons");
+    }
+    const existingIds = new Set(existing.map((l) => l.id));
+    for (const id of data.lessonIds) {
+      if (!existingIds.has(id)) {
+        throw new Error("Lesson list does not match module lessons");
+      }
+    }
+
+    // Atomic update: set each lesson's position to its index in the list
+    const reordered = await db.transaction(async (tx) => {
+      for (let i = 0; i < data.lessonIds.length; i++) {
+        await tx.update(lessons).set({ position: i }).where(eq(lessons.id, data.lessonIds[i]));
+      }
+
+      return tx.query.lessons.findMany({
+        where: eq(lessons.moduleId, data.moduleId),
+        orderBy: [asc(lessons.position)],
+      });
+    });
+
+    return reordered;
   });

--- a/src/routes/admin/courses/$courseId.tsx
+++ b/src/routes/admin/courses/$courseId.tsx
@@ -10,8 +10,10 @@ import {
   updateCourseFn,
   createModuleFn,
   deleteModuleFn,
+  reorderModulesFn,
   createLessonFn,
   deleteLessonFn,
+  reorderLessonsFn,
 } from "#/lib/courses.ts";
 
 type Module = typeof modules.$inferSelect;
@@ -141,6 +143,59 @@ function CourseDetailPage() {
     }));
   }
 
+  async function handleMoveModule(moduleId: string, direction: "up" | "down") {
+    const currentIndex = moduleList.findIndex((m) => m.id === moduleId);
+    if (currentIndex === -1) return;
+    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= moduleList.length) return;
+
+    const reordered = [...moduleList];
+    [reordered[currentIndex], reordered[targetIndex]] = [
+      reordered[targetIndex],
+      reordered[currentIndex],
+    ];
+
+    // Optimistic update
+    setModuleList(reordered);
+    try {
+      const updated = await reorderModulesFn({
+        data: { courseId: course.id, moduleIds: reordered.map((m) => m.id) },
+      });
+      setModuleList(updated);
+    } catch (err) {
+      // Revert on error
+      setModuleList(moduleList);
+      alert(err instanceof Error ? err.message : "Failed to reorder modules");
+    }
+  }
+
+  async function handleMoveLesson(moduleId: string, lessonId: string, direction: "up" | "down") {
+    const current = lessonMap[moduleId] || [];
+    const currentIndex = current.findIndex((l) => l.id === lessonId);
+    if (currentIndex === -1) return;
+    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= current.length) return;
+
+    const reordered = [...current];
+    [reordered[currentIndex], reordered[targetIndex]] = [
+      reordered[targetIndex],
+      reordered[currentIndex],
+    ];
+
+    // Optimistic update
+    setLessonMap((prev) => ({ ...prev, [moduleId]: reordered }));
+    try {
+      const updated = await reorderLessonsFn({
+        data: { moduleId, lessonIds: reordered.map((l) => l.id) },
+      });
+      setLessonMap((prev) => ({ ...prev, [moduleId]: updated }));
+    } catch (err) {
+      // Revert on error
+      setLessonMap((prev) => ({ ...prev, [moduleId]: current }));
+      alert(err instanceof Error ? err.message : "Failed to reorder lessons");
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
@@ -250,13 +305,35 @@ function CourseDetailPage() {
       <div className="space-y-4">
         <h2 className="text-lg font-semibold">Modules</h2>
 
-        {moduleList.map((mod) => (
+        {moduleList.map((mod, modIndex) => (
           <div
             key={mod.id}
             className="rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
           >
             <div className="flex items-center justify-between border-b border-neutral-200 p-4 dark:border-neutral-800">
-              <h3 className="font-medium">{mod.title}</h3>
+              <div className="flex items-center gap-2">
+                <div className="flex flex-col">
+                  <button
+                    type="button"
+                    aria-label={`Move module ${mod.title} up`}
+                    onClick={() => handleMoveModule(mod.id, "up")}
+                    disabled={modIndex === 0}
+                    className="px-1 text-xs text-neutral-500 hover:text-neutral-900 disabled:opacity-30 disabled:hover:text-neutral-500 dark:hover:text-neutral-100"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Move module ${mod.title} down`}
+                    onClick={() => handleMoveModule(mod.id, "down")}
+                    disabled={modIndex === moduleList.length - 1}
+                    className="px-1 text-xs text-neutral-500 hover:text-neutral-900 disabled:opacity-30 disabled:hover:text-neutral-500 dark:hover:text-neutral-100"
+                  >
+                    ▼
+                  </button>
+                </div>
+                <h3 className="font-medium">{mod.title}</h3>
+              </div>
               <div className="flex gap-2">
                 <button
                   type="button"
@@ -284,24 +361,49 @@ function CourseDetailPage() {
                 <p className="text-sm text-neutral-500 dark:text-neutral-400">No lessons yet.</p>
               ) : (
                 <ul className="space-y-2">
-                  {(lessonMap[mod.id] || []).map((lesson) => (
-                    <li
-                      key={lesson.id}
-                      className="flex items-center justify-between rounded-md border border-neutral-100 p-3 dark:border-neutral-800"
-                    >
-                      <div>
-                        <span className="text-sm font-medium">{lesson.title}</span>
-                        <span className="ml-2 text-xs text-neutral-400">{lesson.type}</span>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteLesson(lesson.id, mod.id)}
-                        className="text-xs text-red-500 hover:text-red-700"
+                  {(lessonMap[mod.id] || []).map((lesson, lessonIndex) => {
+                    const lessonsForMod = lessonMap[mod.id] || [];
+                    return (
+                      <li
+                        key={lesson.id}
+                        className="flex items-center justify-between rounded-md border border-neutral-100 p-3 dark:border-neutral-800"
                       >
-                        Delete
-                      </button>
-                    </li>
-                  ))}
+                        <div className="flex items-center gap-2">
+                          <div className="flex flex-col">
+                            <button
+                              type="button"
+                              aria-label={`Move lesson ${lesson.title} up`}
+                              onClick={() => handleMoveLesson(mod.id, lesson.id, "up")}
+                              disabled={lessonIndex === 0}
+                              className="px-1 text-xs text-neutral-500 hover:text-neutral-900 disabled:opacity-30 disabled:hover:text-neutral-500 dark:hover:text-neutral-100"
+                            >
+                              ▲
+                            </button>
+                            <button
+                              type="button"
+                              aria-label={`Move lesson ${lesson.title} down`}
+                              onClick={() => handleMoveLesson(mod.id, lesson.id, "down")}
+                              disabled={lessonIndex === lessonsForMod.length - 1}
+                              className="px-1 text-xs text-neutral-500 hover:text-neutral-900 disabled:opacity-30 disabled:hover:text-neutral-500 dark:hover:text-neutral-100"
+                            >
+                              ▼
+                            </button>
+                          </div>
+                          <div>
+                            <span className="text-sm font-medium">{lesson.title}</span>
+                            <span className="ml-2 text-xs text-neutral-400">{lesson.type}</span>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteLesson(lesson.id, mod.id)}
+                          className="text-xs text-red-500 hover:text-red-700"
+                        >
+                          Delete
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
 

--- a/tests/course-reorder.test.ts
+++ b/tests/course-reorder.test.ts
@@ -1,0 +1,441 @@
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { asc, eq } from "drizzle-orm";
+import { db } from "#/db/index.ts";
+import { tenants, courses, modules, lessons } from "#/db/schema/index.ts";
+
+// ── Pure reorder helpers (same logic used by reorderModulesFn / reorderLessonsFn) ──
+
+/**
+ * Persists a reordered list of modules within a course atomically.
+ * Each module's position is set to its index in `orderedIds`.
+ * Validates that `orderedIds` matches the complete set of module IDs in the course.
+ */
+async function persistModuleOrder(courseId: string, orderedIds: string[]): Promise<void> {
+  const existing = await db.query.modules.findMany({
+    where: eq(modules.courseId, courseId),
+    columns: { id: true },
+  });
+
+  if (existing.length !== orderedIds.length) {
+    throw new Error("Module list does not match course modules");
+  }
+  const existingSet = new Set(existing.map((m) => m.id));
+  for (const id of orderedIds) {
+    if (!existingSet.has(id)) {
+      throw new Error("Module list does not match course modules");
+    }
+  }
+
+  await db.transaction(async (tx) => {
+    for (let i = 0; i < orderedIds.length; i++) {
+      await tx.update(modules).set({ position: i }).where(eq(modules.id, orderedIds[i]));
+    }
+  });
+}
+
+/**
+ * Persists a reordered list of lessons within a module atomically.
+ */
+async function persistLessonOrder(moduleId: string, orderedIds: string[]): Promise<void> {
+  const existing = await db.query.lessons.findMany({
+    where: eq(lessons.moduleId, moduleId),
+    columns: { id: true },
+  });
+
+  if (existing.length !== orderedIds.length) {
+    throw new Error("Lesson list does not match module lessons");
+  }
+  const existingSet = new Set(existing.map((l) => l.id));
+  for (const id of orderedIds) {
+    if (!existingSet.has(id)) {
+      throw new Error("Lesson list does not match module lessons");
+    }
+  }
+
+  await db.transaction(async (tx) => {
+    for (let i = 0; i < orderedIds.length; i++) {
+      await tx.update(lessons).set({ position: i }).where(eq(lessons.id, orderedIds[i]));
+    }
+  });
+}
+
+/**
+ * Pure client-side "move up/down" logic: returns a new array with the item
+ * at `index` swapped with its neighbor. Used by the admin UI to derive the
+ * new ordering before sending it to the server.
+ */
+function moveItem<T>(items: T[], index: number, direction: "up" | "down"): T[] {
+  const target = direction === "up" ? index - 1 : index + 1;
+  if (index < 0 || index >= items.length || target < 0 || target >= items.length) {
+    return items;
+  }
+  const next = [...items];
+  [next[index], next[target]] = [next[target], next[index]];
+  return next;
+}
+
+// ── Test fixtures ──────────────────────────────────────────────────────
+
+describe("module/lesson reordering (integration)", () => {
+  const ts = Date.now();
+  let tenantId: string;
+  let courseId: string;
+
+  beforeAll(async () => {
+    const [t] = await db
+      .insert(tenants)
+      .values({ name: "Reorder School", subdomain: `reorder-school-${ts}` })
+      .returning();
+    tenantId = t.id;
+
+    const [c] = await db
+      .insert(courses)
+      .values({
+        tenantId,
+        title: "Reorder Course",
+        slug: `reorder-course-${ts}`,
+      })
+      .returning();
+    courseId = c.id;
+  });
+
+  afterAll(async () => {
+    await db.delete(courses).where(eq(courses.tenantId, tenantId));
+    await db.delete(tenants).where(eq(tenants.id, tenantId));
+  });
+
+  // ── Client-side move logic ─────────────────────────────────────────
+
+  describe("moveItem helper (UI up/down logic)", () => {
+    it("moves an item up by one position", () => {
+      const result = moveItem(["a", "b", "c", "d"], 2, "up");
+      expect(result).toEqual(["a", "c", "b", "d"]);
+    });
+
+    it("moves an item down by one position", () => {
+      const result = moveItem(["a", "b", "c", "d"], 1, "down");
+      expect(result).toEqual(["a", "c", "b", "d"]);
+    });
+
+    it("does not move the first item further up", () => {
+      const result = moveItem(["a", "b", "c"], 0, "up");
+      expect(result).toEqual(["a", "b", "c"]);
+    });
+
+    it("does not move the last item further down", () => {
+      const result = moveItem(["a", "b", "c"], 2, "down");
+      expect(result).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns a new array without mutating the input", () => {
+      const original = ["a", "b", "c"];
+      const result = moveItem(original, 0, "down");
+      expect(original).toEqual(["a", "b", "c"]);
+      expect(result).not.toBe(original);
+    });
+  });
+
+  // ── Module reordering persistence ──────────────────────────────────
+
+  describe("persistModuleOrder", () => {
+    let modAId: string;
+    let modBId: string;
+    let modCId: string;
+
+    beforeAll(async () => {
+      // Isolate this block by using its own course
+      const [c] = await db
+        .insert(courses)
+        .values({ tenantId, title: "Mod Reorder", slug: `mod-reorder-${ts}` })
+        .returning();
+
+      const [a] = await db
+        .insert(modules)
+        .values({ courseId: c.id, title: "Alpha", position: 0 })
+        .returning();
+      const [b] = await db
+        .insert(modules)
+        .values({ courseId: c.id, title: "Beta", position: 1 })
+        .returning();
+      const [cc] = await db
+        .insert(modules)
+        .values({ courseId: c.id, title: "Gamma", position: 2 })
+        .returning();
+
+      modAId = a.id;
+      modBId = b.id;
+      modCId = cc.id;
+
+      // Override the outer test's courseId for this describe block
+      courseId = c.id;
+    });
+
+    it("reorders modules by swapping positions and persists", async () => {
+      // Initial order: Alpha(0), Beta(1), Gamma(2)
+      // Move Beta up → Beta(0), Alpha(1), Gamma(2)
+      await persistModuleOrder(courseId, [modBId, modAId, modCId]);
+
+      const result = await db.query.modules.findMany({
+        where: eq(modules.courseId, courseId),
+        orderBy: [asc(modules.position)],
+      });
+
+      expect(result.map((m) => m.id)).toEqual([modBId, modAId, modCId]);
+      expect(result.map((m) => m.position)).toEqual([0, 1, 2]);
+    });
+
+    it("reorders to a completely new arrangement", async () => {
+      // Reverse: Gamma, Beta, Alpha
+      await persistModuleOrder(courseId, [modCId, modBId, modAId]);
+
+      const result = await db.query.modules.findMany({
+        where: eq(modules.courseId, courseId),
+        orderBy: [asc(modules.position)],
+      });
+
+      expect(result.map((m) => m.id)).toEqual([modCId, modBId, modAId]);
+      expect(result[0].position).toBe(0);
+      expect(result[1].position).toBe(1);
+      expect(result[2].position).toBe(2);
+    });
+
+    it("preserves positions after a reorder round-trip", async () => {
+      await persistModuleOrder(courseId, [modAId, modBId, modCId]);
+
+      // Re-query from a fresh DB read
+      const fresh = await db.query.modules.findMany({
+        where: eq(modules.courseId, courseId),
+        orderBy: [asc(modules.position)],
+      });
+
+      expect(fresh.map((m) => m.title)).toEqual(["Alpha", "Beta", "Gamma"]);
+      expect(fresh.map((m) => m.position)).toEqual([0, 1, 2]);
+    });
+
+    it("rejects reorder if IDs do not match course modules", async () => {
+      await expect(persistModuleOrder(courseId, [modAId, modBId])).rejects.toThrow(
+        /does not match/,
+      );
+    });
+
+    it("rejects reorder if a foreign ID is included", async () => {
+      await expect(
+        persistModuleOrder(courseId, [modAId, modBId, "00000000-0000-0000-0000-000000000000"]),
+      ).rejects.toThrow(/does not match/);
+    });
+
+    it("leaves positions untouched when validation fails", async () => {
+      // Ensure we start from a known order
+      await persistModuleOrder(courseId, [modAId, modBId, modCId]);
+
+      await expect(persistModuleOrder(courseId, [modAId, modBId])).rejects.toThrow();
+
+      const after = await db.query.modules.findMany({
+        where: eq(modules.courseId, courseId),
+        orderBy: [asc(modules.position)],
+      });
+      expect(after.map((m) => m.id)).toEqual([modAId, modBId, modCId]);
+    });
+  });
+
+  // ── Lesson reordering persistence ──────────────────────────────────
+
+  describe("persistLessonOrder", () => {
+    let moduleId: string;
+    let lesson1Id: string;
+    let lesson2Id: string;
+    let lesson3Id: string;
+
+    beforeAll(async () => {
+      const [c] = await db
+        .insert(courses)
+        .values({ tenantId, title: "Lesson Reorder", slug: `lesson-reorder-${ts}` })
+        .returning();
+
+      const [mod] = await db
+        .insert(modules)
+        .values({ courseId: c.id, title: "Only Module", position: 0 })
+        .returning();
+      moduleId = mod.id;
+
+      const [l1] = await db
+        .insert(lessons)
+        .values({ moduleId, title: "Intro", type: "text", position: 0 })
+        .returning();
+      const [l2] = await db
+        .insert(lessons)
+        .values({ moduleId, title: "Middle", type: "video", position: 1 })
+        .returning();
+      const [l3] = await db
+        .insert(lessons)
+        .values({ moduleId, title: "Wrap-up", type: "text", position: 2 })
+        .returning();
+
+      lesson1Id = l1.id;
+      lesson2Id = l2.id;
+      lesson3Id = l3.id;
+    });
+
+    it("reorders lessons within a module and persists", async () => {
+      await persistLessonOrder(moduleId, [lesson3Id, lesson1Id, lesson2Id]);
+
+      const result = await db.query.lessons.findMany({
+        where: eq(lessons.moduleId, moduleId),
+        orderBy: [asc(lessons.position)],
+      });
+
+      expect(result.map((l) => l.id)).toEqual([lesson3Id, lesson1Id, lesson2Id]);
+      expect(result.map((l) => l.position)).toEqual([0, 1, 2]);
+      expect(result.map((l) => l.title)).toEqual(["Wrap-up", "Intro", "Middle"]);
+    });
+
+    it("moves a lesson down via move-item + persist round-trip", async () => {
+      // Start known: Intro(0), Middle(1), Wrap-up(2)
+      await persistLessonOrder(moduleId, [lesson1Id, lesson2Id, lesson3Id]);
+
+      // Simulate clicking "move down" on Intro
+      const current = [lesson1Id, lesson2Id, lesson3Id];
+      const next = moveItem(current, 0, "down");
+      expect(next).toEqual([lesson2Id, lesson1Id, lesson3Id]);
+
+      await persistLessonOrder(moduleId, next);
+
+      const result = await db.query.lessons.findMany({
+        where: eq(lessons.moduleId, moduleId),
+        orderBy: [asc(lessons.position)],
+      });
+      expect(result.map((l) => l.id)).toEqual([lesson2Id, lesson1Id, lesson3Id]);
+    });
+
+    it("moves a lesson up via move-item + persist round-trip", async () => {
+      await persistLessonOrder(moduleId, [lesson1Id, lesson2Id, lesson3Id]);
+
+      // Simulate clicking "move up" on Wrap-up
+      const current = [lesson1Id, lesson2Id, lesson3Id];
+      const next = moveItem(current, 2, "up");
+      expect(next).toEqual([lesson1Id, lesson3Id, lesson2Id]);
+
+      await persistLessonOrder(moduleId, next);
+
+      const result = await db.query.lessons.findMany({
+        where: eq(lessons.moduleId, moduleId),
+        orderBy: [asc(lessons.position)],
+      });
+      expect(result.map((l) => l.id)).toEqual([lesson1Id, lesson3Id, lesson2Id]);
+    });
+
+    it("rejects reorder if IDs do not match module lessons", async () => {
+      await expect(persistLessonOrder(moduleId, [lesson1Id, lesson2Id])).rejects.toThrow(
+        /does not match/,
+      );
+    });
+
+    it("rejects reorder if a foreign lesson ID is included", async () => {
+      await expect(
+        persistLessonOrder(moduleId, [
+          lesson1Id,
+          lesson2Id,
+          "00000000-0000-0000-0000-000000000000",
+        ]),
+      ).rejects.toThrow(/does not match/);
+    });
+  });
+
+  // ── Isolation across sibling modules ───────────────────────────────
+
+  describe("reorder isolation across siblings", () => {
+    it("reordering lessons in one module does not affect another", async () => {
+      const [c] = await db
+        .insert(courses)
+        .values({ tenantId, title: "Isolation", slug: `isolation-${ts}` })
+        .returning();
+
+      const [modA] = await db
+        .insert(modules)
+        .values({ courseId: c.id, title: "Mod A", position: 0 })
+        .returning();
+      const [modB] = await db
+        .insert(modules)
+        .values({ courseId: c.id, title: "Mod B", position: 1 })
+        .returning();
+
+      const [a1] = await db
+        .insert(lessons)
+        .values({ moduleId: modA.id, title: "A1", type: "text", position: 0 })
+        .returning();
+      const [a2] = await db
+        .insert(lessons)
+        .values({ moduleId: modA.id, title: "A2", type: "text", position: 1 })
+        .returning();
+
+      const [b1] = await db
+        .insert(lessons)
+        .values({ moduleId: modB.id, title: "B1", type: "text", position: 0 })
+        .returning();
+      const [b2] = await db
+        .insert(lessons)
+        .values({ moduleId: modB.id, title: "B2", type: "text", position: 1 })
+        .returning();
+
+      // Reorder module A lessons
+      await persistLessonOrder(modA.id, [a2.id, a1.id]);
+
+      // Module A is reordered
+      const resultA = await db.query.lessons.findMany({
+        where: eq(lessons.moduleId, modA.id),
+        orderBy: [asc(lessons.position)],
+      });
+      expect(resultA.map((l) => l.id)).toEqual([a2.id, a1.id]);
+
+      // Module B is untouched
+      const resultB = await db.query.lessons.findMany({
+        where: eq(lessons.moduleId, modB.id),
+        orderBy: [asc(lessons.position)],
+      });
+      expect(resultB.map((l) => l.id)).toEqual([b1.id, b2.id]);
+    });
+
+    it("reordering modules in one course does not affect another", async () => {
+      const [c1] = await db
+        .insert(courses)
+        .values({ tenantId, title: "Course X", slug: `course-x-${ts}` })
+        .returning();
+      const [c2] = await db
+        .insert(courses)
+        .values({ tenantId, title: "Course Y", slug: `course-y-${ts}` })
+        .returning();
+
+      const [x1] = await db
+        .insert(modules)
+        .values({ courseId: c1.id, title: "X1", position: 0 })
+        .returning();
+      const [x2] = await db
+        .insert(modules)
+        .values({ courseId: c1.id, title: "X2", position: 1 })
+        .returning();
+
+      const [y1] = await db
+        .insert(modules)
+        .values({ courseId: c2.id, title: "Y1", position: 0 })
+        .returning();
+      const [y2] = await db
+        .insert(modules)
+        .values({ courseId: c2.id, title: "Y2", position: 1 })
+        .returning();
+
+      await persistModuleOrder(c1.id, [x2.id, x1.id]);
+
+      const result1 = await db.query.modules.findMany({
+        where: eq(modules.courseId, c1.id),
+        orderBy: [asc(modules.position)],
+      });
+      expect(result1.map((m) => m.id)).toEqual([x2.id, x1.id]);
+
+      const result2 = await db.query.modules.findMany({
+        where: eq(modules.courseId, c2.id),
+        orderBy: [asc(modules.position)],
+      });
+      expect(result2.map((m) => m.id)).toEqual([y1.id, y2.id]);
+    });
+  });
+});


### PR DESCRIPTION
Add reorderModulesFn and reorderLessonsFn server functions that
accept an ordered list of IDs and persist each item's position
atomically inside a transaction. The admin course detail page now
renders up/down arrows next to each module and lesson, with
optimistic client-side updates and error-revert on failure.

Closes #20