### PR TITLE
feat: platform plan tiers, enforcement, and metrics dashboard

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,6 +8,7 @@ import { auditLogs } from "#/db/schema/audit-logs.ts";
 import { tenantIdStore } from "./tenant-context.ts";
 import { sendEmail } from "./email.ts";
 import { renderVerifyEmail, renderResetPassword } from "./email-templates/index.ts";
+import { assertCanAddStudent } from "./plans.ts";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -32,11 +33,16 @@ export const auth = betterAuth({
         before: async (user) => {
           const tenantId = tenantIdStore.getStore();
           if (tenantId) {
+            const role = (user as { role?: string }).role || "student";
+            // Enforce plan student cap for student signups
+            if (role === "student") {
+              await assertCanAddStudent(tenantId);
+            }
             return {
               data: {
                 ...user,
                 tenantId,
-                role: user.role || "student",
+                role,
               },
             };
           }
@@ -196,9 +202,7 @@ export const auth = betterAuth({
  * since API methods also await the same promise (and .then() is registered first).
  */
 (auth.$context as Promise<any>).then((ctx: any) => {
-  const originalFindUserByEmail = ctx.internalAdapter.findUserByEmail.bind(
-    ctx.internalAdapter,
-  );
+  const originalFindUserByEmail = ctx.internalAdapter.findUserByEmail.bind(ctx.internalAdapter);
 
   ctx.internalAdapter.findUserByEmail = async (
     email: string,
@@ -208,10 +212,7 @@ export const auth = betterAuth({
     if (!tenantId) return originalFindUserByEmail(email, options);
 
     const user = await db.query.users.findFirst({
-      where: and(
-        eq(schema.users.email, email.toLowerCase()),
-        eq(schema.users.tenantId, tenantId),
-      ),
+      where: and(eq(schema.users.email, email.toLowerCase()), eq(schema.users.tenantId, tenantId)),
     });
     if (!user) return null;
 

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -5,6 +5,7 @@ import { db } from "#/db/index.ts";
 import { courses, modules, lessons } from "#/db/schema/index.ts";
 import type { LessonContent } from "#/lib/rich-text/types.ts";
 import { auth } from "./auth.ts";
+import { assertCanCreateCourse } from "./plans.ts";
 
 type SessionUser = { id: string; role: string; tenantId: string };
 
@@ -80,6 +81,9 @@ export const createCourseFn = createServerFn({ method: "POST" })
       columns: { id: true },
     });
     if (existing) throw new Error("A course with this slug already exists");
+
+    // Enforce plan constraints (max courses per tenant)
+    await assertCanCreateCourse(user.tenantId);
 
     const [course] = await db
       .insert(courses)

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,271 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { and, count, eq } from "drizzle-orm";
+import { db } from "#/db/index.ts";
+import { courses, plans, tenants, users } from "#/db/schema/index.ts";
+import { auth } from "./auth.ts";
+
+// ── Plan shape helpers ───────────────────────────────────────────────
+
+export type PlanInput = {
+  name: string;
+  maxCourses: number | null;
+  maxStudents: number | null;
+  applicationFeePercent: string | null;
+};
+
+function normalizePlanInput(input: {
+  name: string;
+  maxCourses?: number | null;
+  maxStudents?: number | null;
+  applicationFeePercent?: string | null;
+}): PlanInput {
+  const name = input.name.trim();
+  if (!name) {
+    throw new Error("Plan name is required");
+  }
+
+  const maxCourses =
+    input.maxCourses === null || input.maxCourses === undefined ? null : Number(input.maxCourses);
+  if (maxCourses !== null && (!Number.isInteger(maxCourses) || maxCourses < 0)) {
+    throw new Error("maxCourses must be a non-negative integer or null");
+  }
+
+  const maxStudents =
+    input.maxStudents === null || input.maxStudents === undefined
+      ? null
+      : Number(input.maxStudents);
+  if (maxStudents !== null && (!Number.isInteger(maxStudents) || maxStudents < 0)) {
+    throw new Error("maxStudents must be a non-negative integer or null");
+  }
+
+  let applicationFeePercent: string | null = null;
+  if (input.applicationFeePercent !== null && input.applicationFeePercent !== undefined) {
+    const raw = String(input.applicationFeePercent).trim();
+    if (raw !== "") {
+      const parsed = Number(raw);
+      if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
+        throw new Error("applicationFeePercent must be between 0 and 100");
+      }
+      applicationFeePercent = parsed.toFixed(2);
+    }
+  }
+
+  return { name, maxCourses, maxStudents, applicationFeePercent };
+}
+
+// ── Access control ───────────────────────────────────────────────────
+
+async function requirePlatformAdmin() {
+  const request = getRequest();
+  const session = await auth.api.getSession({ headers: request.headers });
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  const user = session.user as { id: string; role?: string };
+  if (user.role !== "platform_admin") {
+    throw new Error("Forbidden");
+  }
+
+  return session;
+}
+
+// ── Plan CRUD server functions ───────────────────────────────────────
+
+export const listPlansFn = createServerFn({ method: "GET" }).handler(async () => {
+  await requirePlatformAdmin();
+
+  const allPlans = await db.query.plans.findMany({
+    orderBy: (p, { asc }) => [asc(p.name)],
+  });
+
+  const tenantCounts = await db
+    .select({ planId: tenants.planId, total: count() })
+    .from(tenants)
+    .groupBy(tenants.planId);
+
+  const countMap = new Map(tenantCounts.map((c) => [c.planId ?? null, c.total]));
+
+  return allPlans.map((plan) => ({
+    ...plan,
+    tenantCount: countMap.get(plan.id) ?? 0,
+  }));
+});
+
+export const getPlanByIdFn = createServerFn({ method: "GET" })
+  .inputValidator((input: { planId: string }) => input)
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const plan = await db.query.plans.findFirst({
+      where: eq(plans.id, data.planId),
+    });
+
+    if (!plan) {
+      throw new Error("Plan not found");
+    }
+
+    return plan;
+  });
+
+export const createPlanFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (input: {
+      name: string;
+      maxCourses?: number | null;
+      maxStudents?: number | null;
+      applicationFeePercent?: string | null;
+    }) => input,
+  )
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const normalized = normalizePlanInput(data);
+
+    const [created] = await db
+      .insert(plans)
+      .values({
+        name: normalized.name,
+        maxCourses: normalized.maxCourses,
+        maxStudents: normalized.maxStudents,
+        applicationFeePercent: normalized.applicationFeePercent,
+      })
+      .returning();
+
+    return created;
+  });
+
+export const updatePlanFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (input: {
+      planId: string;
+      name: string;
+      maxCourses?: number | null;
+      maxStudents?: number | null;
+      applicationFeePercent?: string | null;
+    }) => input,
+  )
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const existing = await db.query.plans.findFirst({
+      where: eq(plans.id, data.planId),
+      columns: { id: true },
+    });
+    if (!existing) {
+      throw new Error("Plan not found");
+    }
+
+    const normalized = normalizePlanInput(data);
+
+    const [updated] = await db
+      .update(plans)
+      .set({
+        name: normalized.name,
+        maxCourses: normalized.maxCourses,
+        maxStudents: normalized.maxStudents,
+        applicationFeePercent: normalized.applicationFeePercent,
+      })
+      .where(eq(plans.id, data.planId))
+      .returning();
+
+    return updated;
+  });
+
+export const deletePlanFn = createServerFn({ method: "POST" })
+  .inputValidator((input: { planId: string }) => input)
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const inUse = await db.query.tenants.findFirst({
+      where: eq(tenants.planId, data.planId),
+      columns: { id: true },
+    });
+    if (inUse) {
+      return { error: "Plan is assigned to one or more tenants and cannot be deleted." };
+    }
+
+    await db.delete(plans).where(eq(plans.id, data.planId));
+    return { error: null };
+  });
+
+// ── Enforcement helpers (pure, no auth) ──────────────────────────────
+
+type PlanLimits = {
+  maxCourses: number | null;
+  maxStudents: number | null;
+  applicationFeePercent: string | null;
+};
+
+async function loadTenantPlan(tenantId: string): Promise<PlanLimits | null> {
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.id, tenantId),
+    columns: { planId: true },
+  });
+
+  if (!tenant?.planId) return null;
+
+  const plan = await db.query.plans.findFirst({
+    where: eq(plans.id, tenant.planId),
+    columns: {
+      maxCourses: true,
+      maxStudents: true,
+      applicationFeePercent: true,
+    },
+  });
+
+  return plan ?? null;
+}
+
+/**
+ * Throws if the tenant already has maxCourses courses for their plan.
+ * Tenants without a plan are treated as unlimited.
+ */
+export async function assertCanCreateCourse(tenantId: string): Promise<void> {
+  const plan = await loadTenantPlan(tenantId);
+  if (!plan || plan.maxCourses === null) return;
+
+  const [row] = await db
+    .select({ total: count() })
+    .from(courses)
+    .where(eq(courses.tenantId, tenantId));
+  const current = row?.total ?? 0;
+
+  if (current >= plan.maxCourses) {
+    throw new Error(
+      `Plan limit reached: this school can have at most ${plan.maxCourses} course(s).`,
+    );
+  }
+}
+
+/**
+ * Throws if the tenant already has maxStudents students for their plan.
+ * Tenants without a plan are treated as unlimited.
+ */
+export async function assertCanAddStudent(tenantId: string): Promise<void> {
+  const plan = await loadTenantPlan(tenantId);
+  if (!plan || plan.maxStudents === null) return;
+
+  const [row] = await db
+    .select({ total: count() })
+    .from(users)
+    .where(and(eq(users.tenantId, tenantId), eq(users.role, "student")));
+  const current = row?.total ?? 0;
+
+  if (current >= plan.maxStudents) {
+    throw new Error(
+      `Plan limit reached: this school can have at most ${plan.maxStudents} student(s).`,
+    );
+  }
+}
+
+/**
+ * Returns the application fee percent for a tenant's plan, or null if no plan
+ * or no fee configured. Returned as a decimal string (e.g. "2.50").
+ */
+export async function getTenantApplicationFeePercent(tenantId: string): Promise<string | null> {
+  const plan = await loadTenantPlan(tenantId);
+  return plan?.applicationFeePercent ?? null;
+}

--- a/src/lib/platform-admin.ts
+++ b/src/lib/platform-admin.ts
@@ -1,8 +1,8 @@
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
-import { count, eq } from "drizzle-orm";
+import { count, eq, sql } from "drizzle-orm";
 import { db } from "#/db/index.ts";
-import { tenants, users, plans } from "#/db/schema/index.ts";
+import { courses, payments, tenants, users, plans } from "#/db/schema/index.ts";
 import { auth } from "./auth.ts";
 
 async function requirePlatformAdmin() {
@@ -104,3 +104,67 @@ export const updateTenantStatusFn = createServerFn({ method: "POST" })
 
     return { error: null };
   });
+
+export const updateTenantPlanFn = createServerFn({ method: "POST" })
+  .inputValidator((input: { tenantId: string; planId: string | null }) => input)
+  .handler(async ({ data }) => {
+    await requirePlatformAdmin();
+
+    const tenant = await db.query.tenants.findFirst({
+      where: eq(tenants.id, data.tenantId),
+      columns: { id: true },
+    });
+    if (!tenant) {
+      return { error: "Tenant not found" };
+    }
+
+    if (data.planId !== null) {
+      const plan = await db.query.plans.findFirst({
+        where: eq(plans.id, data.planId),
+        columns: { id: true },
+      });
+      if (!plan) {
+        return { error: "Plan not found" };
+      }
+    }
+
+    await db.update(tenants).set({ planId: data.planId }).where(eq(tenants.id, data.tenantId));
+
+    return { error: null };
+  });
+
+export const getPlatformMetricsFn = createServerFn({ method: "GET" }).handler(async () => {
+  await requirePlatformAdmin();
+
+  const [tenantCountRow] = await db.select({ total: count() }).from(tenants);
+  const [studentCountRow] = await db
+    .select({ total: count() })
+    .from(users)
+    .where(eq(users.role, "student"));
+  const [courseCountRow] = await db.select({ total: count() }).from(courses);
+  const [revenueRow] = await db
+    .select({ total: sql<string>`COALESCE(SUM(${payments.amount}), 0)` })
+    .from(payments);
+
+  const tenantsByStatus = await db
+    .select({ status: tenants.status, total: count() })
+    .from(tenants)
+    .groupBy(tenants.status);
+
+  const statusBreakdown: Record<"active" | "suspended" | "inactive", number> = {
+    active: 0,
+    suspended: 0,
+    inactive: 0,
+  };
+  for (const row of tenantsByStatus) {
+    statusBreakdown[row.status] = row.total;
+  }
+
+  return {
+    tenantCount: tenantCountRow?.total ?? 0,
+    studentCount: studentCountRow?.total ?? 0,
+    courseCount: courseCountRow?.total ?? 0,
+    totalRevenue: revenueRow?.total ?? "0",
+    tenantsByStatus: statusBreakdown,
+  };
+});

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,8 +22,12 @@ import { Route as IndexRouteImport } from "./routes/index";
 import { Route as PlatformAdminIndexRouteImport } from "./routes/platform-admin/index";
 import { Route as AdminIndexRouteImport } from "./routes/admin/index";
 import { Route as AdminOnboardingRouteImport } from "./routes/admin/onboarding";
+import { Route as PlatformAdminTenantsIndexRouteImport } from "./routes/platform-admin/tenants/index";
+import { Route as PlatformAdminPlansIndexRouteImport } from "./routes/platform-admin/plans/index";
 import { Route as AdminCoursesIndexRouteImport } from "./routes/admin/courses/index";
 import { Route as PlatformAdminTenantsTenantIdRouteImport } from "./routes/platform-admin/tenants/$tenantId";
+import { Route as PlatformAdminPlansNewRouteImport } from "./routes/platform-admin/plans/new";
+import { Route as PlatformAdminPlansPlanIdRouteImport } from "./routes/platform-admin/plans/$planId";
 import { Route as ApiWebhooksStripeRouteImport } from "./routes/api/webhooks/stripe";
 import { Route as ApiWebhooksBunnyRouteImport } from "./routes/api/webhooks/bunny";
 import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
@@ -94,6 +98,16 @@ const AdminOnboardingRoute = AdminOnboardingRouteImport.update({
   path: "/onboarding",
   getParentRoute: () => AdminRouteRoute,
 } as any);
+const PlatformAdminTenantsIndexRoute = PlatformAdminTenantsIndexRouteImport.update({
+  id: "/tenants/",
+  path: "/tenants/",
+  getParentRoute: () => PlatformAdminRouteRoute,
+} as any);
+const PlatformAdminPlansIndexRoute = PlatformAdminPlansIndexRouteImport.update({
+  id: "/plans/",
+  path: "/plans/",
+  getParentRoute: () => PlatformAdminRouteRoute,
+} as any);
 const AdminCoursesIndexRoute = AdminCoursesIndexRouteImport.update({
   id: "/courses/",
   path: "/courses/",
@@ -102,6 +116,16 @@ const AdminCoursesIndexRoute = AdminCoursesIndexRouteImport.update({
 const PlatformAdminTenantsTenantIdRoute = PlatformAdminTenantsTenantIdRouteImport.update({
   id: "/tenants/$tenantId",
   path: "/tenants/$tenantId",
+  getParentRoute: () => PlatformAdminRouteRoute,
+} as any);
+const PlatformAdminPlansNewRoute = PlatformAdminPlansNewRouteImport.update({
+  id: "/plans/new",
+  path: "/plans/new",
+  getParentRoute: () => PlatformAdminRouteRoute,
+} as any);
+const PlatformAdminPlansPlanIdRoute = PlatformAdminPlansPlanIdRouteImport.update({
+  id: "/plans/$planId",
+  path: "/plans/$planId",
   getParentRoute: () => PlatformAdminRouteRoute,
 } as any);
 const ApiWebhooksStripeRoute = ApiWebhooksStripeRouteImport.update({
@@ -143,8 +167,12 @@ export interface FileRoutesByFullPath {
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/api/webhooks/bunny": typeof ApiWebhooksBunnyRoute;
   "/api/webhooks/stripe": typeof ApiWebhooksStripeRoute;
+  "/platform-admin/plans/$planId": typeof PlatformAdminPlansPlanIdRoute;
+  "/platform-admin/plans/new": typeof PlatformAdminPlansNewRoute;
   "/platform-admin/tenants/$tenantId": typeof PlatformAdminTenantsTenantIdRoute;
   "/admin/courses/": typeof AdminCoursesIndexRoute;
+  "/platform-admin/plans/": typeof PlatformAdminPlansIndexRoute;
+  "/platform-admin/tenants/": typeof PlatformAdminTenantsIndexRoute;
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
@@ -162,8 +190,12 @@ export interface FileRoutesByTo {
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/api/webhooks/bunny": typeof ApiWebhooksBunnyRoute;
   "/api/webhooks/stripe": typeof ApiWebhooksStripeRoute;
+  "/platform-admin/plans/$planId": typeof PlatformAdminPlansPlanIdRoute;
+  "/platform-admin/plans/new": typeof PlatformAdminPlansNewRoute;
   "/platform-admin/tenants/$tenantId": typeof PlatformAdminTenantsTenantIdRoute;
   "/admin/courses": typeof AdminCoursesIndexRoute;
+  "/platform-admin/plans": typeof PlatformAdminPlansIndexRoute;
+  "/platform-admin/tenants": typeof PlatformAdminTenantsIndexRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
@@ -184,8 +216,12 @@ export interface FileRoutesById {
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/api/webhooks/bunny": typeof ApiWebhooksBunnyRoute;
   "/api/webhooks/stripe": typeof ApiWebhooksStripeRoute;
+  "/platform-admin/plans/$planId": typeof PlatformAdminPlansPlanIdRoute;
+  "/platform-admin/plans/new": typeof PlatformAdminPlansNewRoute;
   "/platform-admin/tenants/$tenantId": typeof PlatformAdminTenantsTenantIdRoute;
   "/admin/courses/": typeof AdminCoursesIndexRoute;
+  "/platform-admin/plans/": typeof PlatformAdminPlansIndexRoute;
+  "/platform-admin/tenants/": typeof PlatformAdminTenantsIndexRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
@@ -207,8 +243,12 @@ export interface FileRouteTypes {
     | "/api/auth/$"
     | "/api/webhooks/bunny"
     | "/api/webhooks/stripe"
+    | "/platform-admin/plans/$planId"
+    | "/platform-admin/plans/new"
     | "/platform-admin/tenants/$tenantId"
-    | "/admin/courses/";
+    | "/admin/courses/"
+    | "/platform-admin/plans/"
+    | "/platform-admin/tenants/";
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
@@ -226,8 +266,12 @@ export interface FileRouteTypes {
     | "/api/auth/$"
     | "/api/webhooks/bunny"
     | "/api/webhooks/stripe"
+    | "/platform-admin/plans/$planId"
+    | "/platform-admin/plans/new"
     | "/platform-admin/tenants/$tenantId"
-    | "/admin/courses";
+    | "/admin/courses"
+    | "/platform-admin/plans"
+    | "/platform-admin/tenants";
   id:
     | "__root__"
     | "/"
@@ -247,8 +291,12 @@ export interface FileRouteTypes {
     | "/api/auth/$"
     | "/api/webhooks/bunny"
     | "/api/webhooks/stripe"
+    | "/platform-admin/plans/$planId"
+    | "/platform-admin/plans/new"
     | "/platform-admin/tenants/$tenantId"
-    | "/admin/courses/";
+    | "/admin/courses/"
+    | "/platform-admin/plans/"
+    | "/platform-admin/tenants/";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
@@ -360,6 +408,20 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AdminOnboardingRouteImport;
       parentRoute: typeof AdminRouteRoute;
     };
+    "/platform-admin/tenants/": {
+      id: "/platform-admin/tenants/";
+      path: "/tenants";
+      fullPath: "/platform-admin/tenants/";
+      preLoaderRoute: typeof PlatformAdminTenantsIndexRouteImport;
+      parentRoute: typeof PlatformAdminRouteRoute;
+    };
+    "/platform-admin/plans/": {
+      id: "/platform-admin/plans/";
+      path: "/plans";
+      fullPath: "/platform-admin/plans/";
+      preLoaderRoute: typeof PlatformAdminPlansIndexRouteImport;
+      parentRoute: typeof PlatformAdminRouteRoute;
+    };
     "/admin/courses/": {
       id: "/admin/courses/";
       path: "/courses";
@@ -372,6 +434,20 @@ declare module "@tanstack/react-router" {
       path: "/tenants/$tenantId";
       fullPath: "/platform-admin/tenants/$tenantId";
       preLoaderRoute: typeof PlatformAdminTenantsTenantIdRouteImport;
+      parentRoute: typeof PlatformAdminRouteRoute;
+    };
+    "/platform-admin/plans/new": {
+      id: "/platform-admin/plans/new";
+      path: "/plans/new";
+      fullPath: "/platform-admin/plans/new";
+      preLoaderRoute: typeof PlatformAdminPlansNewRouteImport;
+      parentRoute: typeof PlatformAdminRouteRoute;
+    };
+    "/platform-admin/plans/$planId": {
+      id: "/platform-admin/plans/$planId";
+      path: "/plans/$planId";
+      fullPath: "/platform-admin/plans/$planId";
+      preLoaderRoute: typeof PlatformAdminPlansPlanIdRouteImport;
       parentRoute: typeof PlatformAdminRouteRoute;
     };
     "/api/webhooks/stripe": {
@@ -423,12 +499,20 @@ const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(AdminRouteR
 
 interface PlatformAdminRouteRouteChildren {
   PlatformAdminIndexRoute: typeof PlatformAdminIndexRoute;
+  PlatformAdminPlansPlanIdRoute: typeof PlatformAdminPlansPlanIdRoute;
+  PlatformAdminPlansNewRoute: typeof PlatformAdminPlansNewRoute;
   PlatformAdminTenantsTenantIdRoute: typeof PlatformAdminTenantsTenantIdRoute;
+  PlatformAdminPlansIndexRoute: typeof PlatformAdminPlansIndexRoute;
+  PlatformAdminTenantsIndexRoute: typeof PlatformAdminTenantsIndexRoute;
 }
 
 const PlatformAdminRouteRouteChildren: PlatformAdminRouteRouteChildren = {
   PlatformAdminIndexRoute: PlatformAdminIndexRoute,
+  PlatformAdminPlansPlanIdRoute: PlatformAdminPlansPlanIdRoute,
+  PlatformAdminPlansNewRoute: PlatformAdminPlansNewRoute,
   PlatformAdminTenantsTenantIdRoute: PlatformAdminTenantsTenantIdRoute,
+  PlatformAdminPlansIndexRoute: PlatformAdminPlansIndexRoute,
+  PlatformAdminTenantsIndexRoute: PlatformAdminTenantsIndexRoute,
 };
 
 const PlatformAdminRouteRouteWithChildren = PlatformAdminRouteRoute._addFileChildren(

--- a/src/routes/platform-admin/index.tsx
+++ b/src/routes/platform-admin/index.tsx
@@ -1,79 +1,85 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { listTenantsFn } from "#/lib/platform-admin.ts";
+import { createFileRoute } from "@tanstack/react-router";
+import { getPlatformMetricsFn } from "#/lib/platform-admin.ts";
 
 export const Route = createFileRoute("/platform-admin/")({
-  loader: () => listTenantsFn(),
-  component: TenantListPage,
+  loader: () => getPlatformMetricsFn(),
+  component: DashboardPage,
 });
 
-const STATUS_STYLES: Record<string, string> = {
-  active: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-  suspended: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
-  inactive: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
-};
+function formatCurrency(amount: string): string {
+  const num = Number(amount);
+  if (Number.isNaN(num)) return "$0.00";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(num);
+}
 
-function TenantListPage() {
-  const tenants = Route.useLoaderData();
+function DashboardPage() {
+  const metrics = Route.useLoaderData();
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">Tenant Management</h1>
+        <h1 className="text-2xl font-bold tracking-tight">Platform Dashboard</h1>
         <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
-          View and manage all tenants on the platform.
+          Aggregate metrics across every school on the platform.
         </p>
       </div>
 
-      {tenants.length === 0 ? (
-        <p className="text-neutral-500 dark:text-neutral-400">No tenants found.</p>
-      ) : (
-        <div className="overflow-x-auto rounded-lg border border-neutral-200 dark:border-neutral-800">
-          <table className="w-full text-left text-sm">
-            <thead className="border-b border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
-              <tr>
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Subdomain</th>
-                <th className="px-4 py-3 font-medium">Status</th>
-                <th className="px-4 py-3 font-medium">Plan</th>
-                <th className="px-4 py-3 font-medium text-right">Students</th>
-                <th className="px-4 py-3 font-medium">Created</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
-              {tenants.map((tenant) => (
-                <tr key={tenant.id} className="bg-white dark:bg-neutral-950">
-                  <td className="px-4 py-3">
-                    <Link
-                      to="/platform-admin/tenants/$tenantId"
-                      params={{ tenantId: tenant.id }}
-                      className="font-medium text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                      {tenant.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
-                    {tenant.subdomain}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[tenant.status] ?? ""}`}
-                    >
-                      {tenant.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
-                    {tenant.planName ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums">{tenant.studentCount}</td>
-                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
-                    {new Date(tenant.createdAt).toLocaleDateString()}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricCard label="Total tenants" value={metrics.tenantCount.toString()} />
+        <MetricCard label="Total students" value={metrics.studentCount.toString()} />
+        <MetricCard label="Total courses" value={metrics.courseCount.toString()} />
+        <MetricCard label="Total revenue" value={formatCurrency(metrics.totalRevenue)} />
+      </div>
+
+      <div className="rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h2 className="text-lg font-semibold">Tenants by status</h2>
+        <dl className="mt-4 grid gap-4 sm:grid-cols-3">
+          <StatusRow label="Active" value={metrics.tenantsByStatus.active} tone="green" />
+          <StatusRow label="Suspended" value={metrics.tenantsByStatus.suspended} tone="yellow" />
+          <StatusRow label="Inactive" value={metrics.tenantsByStatus.inactive} tone="red" />
+        </dl>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <p className="text-xs font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-bold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+const TONE_STYLES = {
+  green: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  yellow: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  red: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+} as const;
+
+function StatusRow({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: keyof typeof TONE_STYLES;
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-neutral-100 px-4 py-3 dark:border-neutral-800">
+      <span
+        className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${TONE_STYLES[tone]}`}
+      >
+        {label}
+      </span>
+      <span className="text-lg font-semibold tabular-nums">{value}</span>
     </div>
   );
 }

--- a/src/routes/platform-admin/plans/$planId.tsx
+++ b/src/routes/platform-admin/plans/$planId.tsx
@@ -1,0 +1,156 @@
+import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-router";
+import { useState } from "react";
+import { getPlanByIdFn, updatePlanFn } from "#/lib/plans.ts";
+
+export const Route = createFileRoute("/platform-admin/plans/$planId")({
+  loader: ({ params }) => getPlanByIdFn({ data: { planId: params.planId } }),
+  component: EditPlanPage,
+});
+
+function EditPlanPage() {
+  const plan = Route.useLoaderData();
+  const router = useRouter();
+  const navigate = useNavigate();
+  const [name, setName] = useState(plan.name);
+  const [maxCourses, setMaxCourses] = useState(
+    plan.maxCourses === null ? "" : String(plan.maxCourses),
+  );
+  const [maxStudents, setMaxStudents] = useState(
+    plan.maxStudents === null ? "" : String(plan.maxStudents),
+  );
+  const [fee, setFee] = useState(plan.applicationFeePercent ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    setSaving(true);
+    try {
+      await updatePlanFn({
+        data: {
+          planId: plan.id,
+          name,
+          maxCourses: maxCourses === "" ? null : Number(maxCourses),
+          maxStudents: maxStudents === "" ? null : Number(maxStudents),
+          applicationFeePercent: fee === "" ? null : fee,
+        },
+      });
+      setMessage("Plan updated successfully.");
+      void router.invalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update plan");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          to="/platform-admin/plans"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          &larr; Back to plans
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">Edit Plan: {plan.name}</h1>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="max-w-xl space-y-4 rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+      >
+        <Field label="Name" htmlFor="plan-name">
+          <input
+            id="plan-name"
+            type="text"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        <Field label="Max courses (blank = unlimited)" htmlFor="plan-max-courses">
+          <input
+            id="plan-max-courses"
+            type="number"
+            min="0"
+            value={maxCourses}
+            onChange={(e) => setMaxCourses(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        <Field label="Max students (blank = unlimited)" htmlFor="plan-max-students">
+          <input
+            id="plan-max-students"
+            type="number"
+            min="0"
+            value={maxStudents}
+            onChange={(e) => setMaxStudents(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        <Field label="Application fee % (blank = none)" htmlFor="plan-fee">
+          <input
+            id="plan-fee"
+            type="number"
+            min="0"
+            max="100"
+            step="0.01"
+            value={fee}
+            onChange={(e) => setFee(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+        {message && <p className="text-sm text-green-600 dark:text-green-400">{message}</p>}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate({ to: "/platform-admin/plans" })}
+            className="text-sm text-neutral-600 hover:underline dark:text-neutral-400"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/routes/platform-admin/plans/index.tsx
+++ b/src/routes/platform-admin/plans/index.tsx
@@ -1,0 +1,107 @@
+import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
+import { useState } from "react";
+import { deletePlanFn, listPlansFn } from "#/lib/plans.ts";
+
+export const Route = createFileRoute("/platform-admin/plans/")({
+  loader: () => listPlansFn(),
+  component: PlanListPage,
+});
+
+function PlanListPage() {
+  const plans = Route.useLoaderData();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  async function handleDelete(planId: string) {
+    setDeletingId(planId);
+    setMessage(null);
+    const result = await deletePlanFn({ data: { planId } });
+    setDeletingId(null);
+    if (result.error) {
+      setMessage(result.error);
+    } else {
+      void router.invalidate();
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Plan Tiers</h1>
+          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+            Configure plan tiers with feature caps and application fee percentages.
+          </p>
+        </div>
+        <Link
+          to="/platform-admin/plans/new"
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          New plan
+        </Link>
+      </div>
+
+      {message && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+          {message}
+        </div>
+      )}
+
+      {plans.length === 0 ? (
+        <p className="text-neutral-500 dark:text-neutral-400">
+          No plans configured yet. Create one to start enforcing limits.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-neutral-200 dark:border-neutral-800">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
+              <tr>
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium text-right">Max courses</th>
+                <th className="px-4 py-3 font-medium text-right">Max students</th>
+                <th className="px-4 py-3 font-medium text-right">Fee %</th>
+                <th className="px-4 py-3 font-medium text-right">Tenants</th>
+                <th className="px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+              {plans.map((plan) => (
+                <tr key={plan.id} className="bg-white dark:bg-neutral-950">
+                  <td className="px-4 py-3">
+                    <Link
+                      to="/platform-admin/plans/$planId"
+                      params={{ planId: plan.id }}
+                      className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {plan.name}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">{plan.maxCourses ?? "∞"}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">{plan.maxStudents ?? "∞"}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {plan.applicationFeePercent ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">{plan.tenantCount}</td>
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(plan.id)}
+                      disabled={deletingId === plan.id || plan.tenantCount > 0}
+                      title={
+                        plan.tenantCount > 0 ? "Reassign tenants before deleting" : "Delete plan"
+                      }
+                      className="text-sm text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400"
+                    >
+                      {deletingId === plan.id ? "Deleting..." : "Delete"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes/platform-admin/plans/new.tsx
+++ b/src/routes/platform-admin/plans/new.tsx
@@ -1,0 +1,143 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { createPlanFn } from "#/lib/plans.ts";
+
+export const Route = createFileRoute("/platform-admin/plans/new")({
+  component: NewPlanPage,
+});
+
+function NewPlanPage() {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [maxCourses, setMaxCourses] = useState("");
+  const [maxStudents, setMaxStudents] = useState("");
+  const [fee, setFee] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaving(true);
+    try {
+      await createPlanFn({
+        data: {
+          name,
+          maxCourses: maxCourses === "" ? null : Number(maxCourses),
+          maxStudents: maxStudents === "" ? null : Number(maxStudents),
+          applicationFeePercent: fee === "" ? null : fee,
+        },
+      });
+      navigate({ to: "/platform-admin/plans" });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create plan");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          to="/platform-admin/plans"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          &larr; Back to plans
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">New Plan</h1>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="max-w-xl space-y-4 rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+      >
+        <Field label="Name" htmlFor="plan-name">
+          <input
+            id="plan-name"
+            type="text"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        <Field label="Max courses (blank = unlimited)" htmlFor="plan-max-courses">
+          <input
+            id="plan-max-courses"
+            type="number"
+            min="0"
+            value={maxCourses}
+            onChange={(e) => setMaxCourses(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        <Field label="Max students (blank = unlimited)" htmlFor="plan-max-students">
+          <input
+            id="plan-max-students"
+            type="number"
+            min="0"
+            value={maxStudents}
+            onChange={(e) => setMaxStudents(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        <Field label="Application fee % (blank = none)" htmlFor="plan-fee">
+          <input
+            id="plan-fee"
+            type="number"
+            min="0"
+            max="100"
+            step="0.01"
+            value={fee}
+            onChange={(e) => setFee(e.target.value)}
+            className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+          />
+        </Field>
+
+        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? "Creating..." : "Create plan"}
+          </button>
+          <Link
+            to="/platform-admin/plans"
+            className="text-sm text-neutral-600 hover:underline dark:text-neutral-400"
+          >
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/routes/platform-admin/route.tsx
+++ b/src/routes/platform-admin/route.tsx
@@ -1,4 +1,4 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+import { Link, Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { getSessionFn } from "#/lib/auth-session.ts";
 import type { User } from "#/lib/auth.ts";
 
@@ -22,6 +22,30 @@ export const Route = createFileRoute("/platform-admin")({
 function PlatformAdminLayout() {
   return (
     <main className="page-wrap py-8">
+      <nav className="mb-6 flex flex-wrap gap-4 border-b border-neutral-200 pb-4 text-sm dark:border-neutral-800">
+        <Link
+          to="/platform-admin"
+          activeOptions={{ exact: true }}
+          activeProps={{ className: "font-semibold text-blue-600 dark:text-blue-400" }}
+          className="text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+        >
+          Dashboard
+        </Link>
+        <Link
+          to="/platform-admin/tenants"
+          activeProps={{ className: "font-semibold text-blue-600 dark:text-blue-400" }}
+          className="text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+        >
+          Tenants
+        </Link>
+        <Link
+          to="/platform-admin/plans"
+          activeProps={{ className: "font-semibold text-blue-600 dark:text-blue-400" }}
+          className="text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+        >
+          Plans
+        </Link>
+      </nav>
       <Outlet />
     </main>
   );

--- a/src/routes/platform-admin/tenants/$tenantId.tsx
+++ b/src/routes/platform-admin/tenants/$tenantId.tsx
@@ -1,9 +1,20 @@
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { useState } from "react";
-import { getTenantDetailFn, updateTenantStatusFn } from "#/lib/platform-admin.ts";
+import {
+  getTenantDetailFn,
+  updateTenantPlanFn,
+  updateTenantStatusFn,
+} from "#/lib/platform-admin.ts";
+import { listPlansFn } from "#/lib/plans.ts";
 
 export const Route = createFileRoute("/platform-admin/tenants/$tenantId")({
-  loader: ({ params }) => getTenantDetailFn({ data: { tenantId: params.tenantId } }),
+  loader: async ({ params }) => {
+    const [tenant, plans] = await Promise.all([
+      getTenantDetailFn({ data: { tenantId: params.tenantId } }),
+      listPlansFn(),
+    ]);
+    return { tenant, plans };
+  },
   component: TenantDetailPage,
 });
 
@@ -16,27 +27,46 @@ const STATUS_STYLES: Record<string, string> = {
 };
 
 function TenantDetailPage() {
-  const tenant = Route.useLoaderData();
+  const { tenant, plans } = Route.useLoaderData();
   const router = useRouter();
   const [status, setStatus] = useState(tenant.status);
-  const [saving, setSaving] = useState(false);
+  const [planId, setPlanId] = useState<string | "">(tenant.planId ?? "");
+  const [savingStatus, setSavingStatus] = useState(false);
+  const [savingPlan, setSavingPlan] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
-  const hasChanged = status !== tenant.status;
+  const statusChanged = status !== tenant.status;
+  const planChanged = (tenant.planId ?? "") !== planId;
 
-  async function handleSave() {
-    setSaving(true);
+  async function handleSaveStatus() {
+    setSavingStatus(true);
     setMessage(null);
     const result = await updateTenantStatusFn({
       data: { tenantId: tenant.id, status },
     });
-    setSaving(false);
+    setSavingStatus(false);
 
     if (result.error) {
       setMessage(result.error);
     } else {
       setMessage("Status updated successfully.");
-      router.invalidate();
+      void router.invalidate();
+    }
+  }
+
+  async function handleSavePlan() {
+    setSavingPlan(true);
+    setMessage(null);
+    const result = await updateTenantPlanFn({
+      data: { tenantId: tenant.id, planId: planId === "" ? null : planId },
+    });
+    setSavingPlan(false);
+
+    if (result.error) {
+      setMessage(result.error);
+    } else {
+      setMessage("Plan updated successfully.");
+      void router.invalidate();
     }
   }
 
@@ -44,7 +74,7 @@ function TenantDetailPage() {
     <div className="space-y-6">
       <div>
         <Link
-          to="/platform-admin"
+          to="/platform-admin/tenants"
           className="text-sm text-blue-600 hover:underline dark:text-blue-400"
         >
           &larr; Back to tenants
@@ -100,17 +130,51 @@ function TenantDetailPage() {
           </div>
           <button
             type="button"
-            onClick={handleSave}
-            disabled={!hasChanged || saving}
+            onClick={handleSaveStatus}
+            disabled={!statusChanged || savingStatus}
             className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
           >
-            {saving ? "Saving..." : "Save"}
+            {savingStatus ? "Saving..." : "Save"}
           </button>
         </div>
-        {message && (
-          <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">{message}</p>
-        )}
       </div>
+
+      <div className="rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h2 className="text-lg font-semibold">Modify Plan</h2>
+        <div className="mt-4 flex items-end gap-4">
+          <div>
+            <label
+              htmlFor="plan-select"
+              className="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+            >
+              Plan
+            </label>
+            <select
+              id="plan-select"
+              value={planId}
+              onChange={(e) => setPlanId(e.target.value)}
+              className="mt-1 rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+            >
+              <option value="">No plan (unlimited)</option>
+              {plans.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={handleSavePlan}
+            disabled={!planChanged || savingPlan}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {savingPlan ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {message && <p className="text-sm text-neutral-600 dark:text-neutral-400">{message}</p>}
     </div>
   );
 }

--- a/src/routes/platform-admin/tenants/index.tsx
+++ b/src/routes/platform-admin/tenants/index.tsx
@@ -1,0 +1,79 @@
+import { Link, createFileRoute } from "@tanstack/react-router";
+import { listTenantsFn } from "#/lib/platform-admin.ts";
+
+export const Route = createFileRoute("/platform-admin/tenants/")({
+  loader: () => listTenantsFn(),
+  component: TenantListPage,
+});
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  suspended: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  inactive: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+};
+
+function TenantListPage() {
+  const tenants = Route.useLoaderData();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Tenant Management</h1>
+        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+          View and manage all tenants on the platform.
+        </p>
+      </div>
+
+      {tenants.length === 0 ? (
+        <p className="text-neutral-500 dark:text-neutral-400">No tenants found.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-neutral-200 dark:border-neutral-800">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
+              <tr>
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Subdomain</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Plan</th>
+                <th className="px-4 py-3 font-medium text-right">Students</th>
+                <th className="px-4 py-3 font-medium">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+              {tenants.map((tenant) => (
+                <tr key={tenant.id} className="bg-white dark:bg-neutral-950">
+                  <td className="px-4 py-3">
+                    <Link
+                      to="/platform-admin/tenants/$tenantId"
+                      params={{ tenantId: tenant.id }}
+                      className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {tenant.name}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
+                    {tenant.subdomain}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[tenant.status] ?? ""}`}
+                    >
+                      {tenant.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
+                    {tenant.planName ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">{tenant.studentCount}</td>
+                  <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400">
+                    {new Date(tenant.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/plans.test.ts
+++ b/tests/plans.test.ts
@@ -1,0 +1,418 @@
+import { and, count, eq, sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { db } from "#/db/index.ts";
+import { courses, payments, plans, tenants, users } from "#/db/schema/index.ts";
+import {
+  assertCanAddStudent,
+  assertCanCreateCourse,
+  getTenantApplicationFeePercent,
+} from "#/lib/plans.ts";
+
+vi.mock("#/lib/email.ts", () => ({
+  sendEmail: vi.fn().mockResolvedValue({ id: "mock-email-id" }),
+}));
+
+describe("plans: configuration, enforcement, and metrics", () => {
+  const ts = Date.now();
+  const smallPlanName = `Starter-${ts}`;
+  const unlimitedPlanName = `Unlimited-${ts}`;
+  let smallPlanId: string;
+  let unlimitedPlanId: string;
+  let tenantSmallId: string;
+  let tenantUnlimitedId: string;
+  let tenantNoPlanId: string;
+
+  beforeAll(async () => {
+    const [small] = await db
+      .insert(plans)
+      .values({
+        name: smallPlanName,
+        maxCourses: 2,
+        maxStudents: 2,
+        applicationFeePercent: "5.00",
+      })
+      .returning();
+    smallPlanId = small.id;
+
+    const [unlimited] = await db
+      .insert(plans)
+      .values({
+        name: unlimitedPlanName,
+        maxCourses: null,
+        maxStudents: null,
+        applicationFeePercent: "1.50",
+      })
+      .returning();
+    unlimitedPlanId = unlimited.id;
+
+    const [tSmall] = await db
+      .insert(tenants)
+      .values({
+        name: `Small School ${ts}`,
+        subdomain: `plan-small-${ts}`,
+        planId: smallPlanId,
+      })
+      .returning();
+    tenantSmallId = tSmall.id;
+
+    const [tUnlimited] = await db
+      .insert(tenants)
+      .values({
+        name: `Unlimited School ${ts}`,
+        subdomain: `plan-unlimited-${ts}`,
+        planId: unlimitedPlanId,
+      })
+      .returning();
+    tenantUnlimitedId = tUnlimited.id;
+
+    const [tNoPlan] = await db
+      .insert(tenants)
+      .values({
+        name: `No Plan School ${ts}`,
+        subdomain: `plan-none-${ts}`,
+      })
+      .returning();
+    tenantNoPlanId = tNoPlan.id;
+  });
+
+  afterAll(async () => {
+    const allTenantIds = [tenantSmallId, tenantUnlimitedId, tenantNoPlanId];
+    for (const tid of allTenantIds) {
+      await db.delete(payments).where(eq(payments.tenantId, tid));
+      await db.delete(courses).where(eq(courses.tenantId, tid));
+      await db.delete(users).where(eq(users.tenantId, tid));
+      await db.delete(tenants).where(eq(tenants.id, tid));
+    }
+    await db.delete(plans).where(eq(plans.id, smallPlanId));
+    await db.delete(plans).where(eq(plans.id, unlimitedPlanId));
+  });
+
+  describe("plan configuration", () => {
+    it("stores name, maxCourses, maxStudents, and applicationFeePercent", async () => {
+      const plan = await db.query.plans.findFirst({
+        where: eq(plans.id, smallPlanId),
+      });
+      expect(plan).toBeDefined();
+      expect(plan!.name).toBe(smallPlanName);
+      expect(plan!.maxCourses).toBe(2);
+      expect(plan!.maxStudents).toBe(2);
+      expect(plan!.applicationFeePercent).toBe("5.00");
+    });
+
+    it("treats null caps as unlimited", async () => {
+      const plan = await db.query.plans.findFirst({
+        where: eq(plans.id, unlimitedPlanId),
+      });
+      expect(plan).toBeDefined();
+      expect(plan!.maxCourses).toBeNull();
+      expect(plan!.maxStudents).toBeNull();
+    });
+
+    it("assigns a plan to a tenant via planId FK", async () => {
+      const tenant = await db.query.tenants.findFirst({
+        where: eq(tenants.id, tenantSmallId),
+      });
+      expect(tenant).toBeDefined();
+      expect(tenant!.planId).toBe(smallPlanId);
+    });
+
+    it("updates plan fields", async () => {
+      const [temp] = await db
+        .insert(plans)
+        .values({
+          name: `UpdateMe-${ts}`,
+          maxCourses: 5,
+          maxStudents: 10,
+          applicationFeePercent: "3.00",
+        })
+        .returning();
+
+      await db
+        .update(plans)
+        .set({ maxCourses: 100, applicationFeePercent: "2.50" })
+        .where(eq(plans.id, temp.id));
+
+      const updated = await db.query.plans.findFirst({
+        where: eq(plans.id, temp.id),
+      });
+      expect(updated!.maxCourses).toBe(100);
+      expect(updated!.applicationFeePercent).toBe("2.50");
+      expect(updated!.maxStudents).toBe(10);
+      expect(updated!.name).toBe(`UpdateMe-${ts}`);
+
+      await db.delete(plans).where(eq(plans.id, temp.id));
+    });
+  });
+
+  describe("course creation constraint validation", () => {
+    it("allows creating courses under the plan cap", async () => {
+      await db
+        .insert(courses)
+        .values({ tenantId: tenantSmallId, title: "Course 1", slug: `c1-${ts}` });
+
+      await expect(assertCanCreateCourse(tenantSmallId)).resolves.toBeUndefined();
+
+      // Clean up
+      await db
+        .delete(courses)
+        .where(and(eq(courses.tenantId, tenantSmallId), eq(courses.slug, `c1-${ts}`)));
+    });
+
+    it("blocks creating courses once the plan cap is reached", async () => {
+      await db
+        .insert(courses)
+        .values({ tenantId: tenantSmallId, title: "Course 1", slug: `c1b-${ts}` });
+      await db
+        .insert(courses)
+        .values({ tenantId: tenantSmallId, title: "Course 2", slug: `c2b-${ts}` });
+
+      await expect(assertCanCreateCourse(tenantSmallId)).rejects.toThrow(/Plan limit reached/);
+
+      // Clean up
+      await db.delete(courses).where(eq(courses.tenantId, tenantSmallId));
+    });
+
+    it("treats tenants without a plan as unlimited", async () => {
+      for (let i = 0; i < 5; i++) {
+        await db
+          .insert(courses)
+          .values({ tenantId: tenantNoPlanId, title: `C${i}`, slug: `np-${ts}-${i}` });
+      }
+      await expect(assertCanCreateCourse(tenantNoPlanId)).resolves.toBeUndefined();
+
+      // Clean up
+      await db.delete(courses).where(eq(courses.tenantId, tenantNoPlanId));
+    });
+
+    it("treats plans with null maxCourses as unlimited", async () => {
+      for (let i = 0; i < 5; i++) {
+        await db
+          .insert(courses)
+          .values({ tenantId: tenantUnlimitedId, title: `U${i}`, slug: `u-${ts}-${i}` });
+      }
+      await expect(assertCanCreateCourse(tenantUnlimitedId)).resolves.toBeUndefined();
+
+      // Clean up
+      await db.delete(courses).where(eq(courses.tenantId, tenantUnlimitedId));
+    });
+  });
+
+  describe("student signup constraint validation", () => {
+    it("allows adding students under the plan cap", async () => {
+      await db.insert(users).values({
+        name: "Student 1",
+        email: `ps1-${ts}@test.com`,
+        tenantId: tenantSmallId,
+        role: "student",
+      });
+      await expect(assertCanAddStudent(tenantSmallId)).resolves.toBeUndefined();
+
+      await db
+        .delete(users)
+        .where(and(eq(users.tenantId, tenantSmallId), eq(users.role, "student")));
+    });
+
+    it("blocks adding students once the plan cap is reached", async () => {
+      await db.insert(users).values({
+        name: "S1",
+        email: `psblock1-${ts}@test.com`,
+        tenantId: tenantSmallId,
+        role: "student",
+      });
+      await db.insert(users).values({
+        name: "S2",
+        email: `psblock2-${ts}@test.com`,
+        tenantId: tenantSmallId,
+        role: "student",
+      });
+
+      await expect(assertCanAddStudent(tenantSmallId)).rejects.toThrow(/Plan limit reached/);
+
+      await db
+        .delete(users)
+        .where(and(eq(users.tenantId, tenantSmallId), eq(users.role, "student")));
+    });
+
+    it("only counts users with role=student toward the cap", async () => {
+      await db.insert(users).values({
+        name: "Owner",
+        email: `owner-${ts}@test.com`,
+        tenantId: tenantSmallId,
+        role: "tenant_owner",
+      });
+      await db.insert(users).values({
+        name: "Admin",
+        email: `admin-${ts}@test.com`,
+        tenantId: tenantSmallId,
+        role: "tenant_admin",
+      });
+
+      // Two non-student users shouldn't consume student slots
+      await expect(assertCanAddStudent(tenantSmallId)).resolves.toBeUndefined();
+
+      await db.delete(users).where(eq(users.tenantId, tenantSmallId));
+    });
+
+    it("treats tenants without a plan as unlimited", async () => {
+      for (let i = 0; i < 10; i++) {
+        await db.insert(users).values({
+          name: `Np${i}`,
+          email: `np-${ts}-${i}@test.com`,
+          tenantId: tenantNoPlanId,
+          role: "student",
+        });
+      }
+      await expect(assertCanAddStudent(tenantNoPlanId)).resolves.toBeUndefined();
+
+      await db.delete(users).where(eq(users.tenantId, tenantNoPlanId));
+    });
+  });
+
+  describe("application fee percentage lookup", () => {
+    it("returns the plan's fee percent for the tenant", async () => {
+      const fee = await getTenantApplicationFeePercent(tenantSmallId);
+      expect(fee).toBe("5.00");
+    });
+
+    it("returns null when the tenant has no plan", async () => {
+      const fee = await getTenantApplicationFeePercent(tenantNoPlanId);
+      expect(fee).toBeNull();
+    });
+  });
+
+  describe("plan modification", () => {
+    it("reassigns a tenant from one plan to another", async () => {
+      const [temp] = await db
+        .insert(tenants)
+        .values({
+          name: `Reassign ${ts}`,
+          subdomain: `reassign-${ts}`,
+          planId: smallPlanId,
+        })
+        .returning();
+
+      expect(temp.planId).toBe(smallPlanId);
+
+      await db.update(tenants).set({ planId: unlimitedPlanId }).where(eq(tenants.id, temp.id));
+
+      const reassigned = await db.query.tenants.findFirst({
+        where: eq(tenants.id, temp.id),
+      });
+      expect(reassigned!.planId).toBe(unlimitedPlanId);
+
+      await db.delete(tenants).where(eq(tenants.id, temp.id));
+    });
+
+    it("removes a tenant's plan by setting planId to null", async () => {
+      const [temp] = await db
+        .insert(tenants)
+        .values({
+          name: `Unassign ${ts}`,
+          subdomain: `unassign-${ts}`,
+          planId: smallPlanId,
+        })
+        .returning();
+
+      await db.update(tenants).set({ planId: null }).where(eq(tenants.id, temp.id));
+
+      const unassigned = await db.query.tenants.findFirst({
+        where: eq(tenants.id, temp.id),
+      });
+      expect(unassigned!.planId).toBeNull();
+
+      await db.delete(tenants).where(eq(tenants.id, temp.id));
+    });
+
+    it("enforcement picks up the new plan after reassignment", async () => {
+      const [temp] = await db
+        .insert(tenants)
+        .values({
+          name: `Enforce ${ts}`,
+          subdomain: `enforce-${ts}`,
+          planId: smallPlanId,
+        })
+        .returning();
+
+      // Fill the small plan's cap of 2 courses
+      await db.insert(courses).values({ tenantId: temp.id, title: "A", slug: `a-${ts}` });
+      await db.insert(courses).values({ tenantId: temp.id, title: "B", slug: `b-${ts}` });
+
+      await expect(assertCanCreateCourse(temp.id)).rejects.toThrow(/Plan limit reached/);
+
+      // Reassign to the unlimited plan — constraint should no longer block
+      await db.update(tenants).set({ planId: unlimitedPlanId }).where(eq(tenants.id, temp.id));
+      await expect(assertCanCreateCourse(temp.id)).resolves.toBeUndefined();
+
+      await db.delete(courses).where(eq(courses.tenantId, temp.id));
+      await db.delete(tenants).where(eq(tenants.id, temp.id));
+    });
+  });
+
+  describe("platform metrics aggregation", () => {
+    it("counts all tenants in the database", async () => {
+      const [row] = await db.select({ total: count() }).from(tenants);
+      expect(row.total).toBeGreaterThanOrEqual(3); // at least our 3 tenants
+    });
+
+    it("counts students across all tenants", async () => {
+      await db.insert(users).values({
+        name: "Metrics S",
+        email: `ms-${ts}@test.com`,
+        tenantId: tenantNoPlanId,
+        role: "student",
+      });
+
+      const [row] = await db
+        .select({ total: count() })
+        .from(users)
+        .where(eq(users.role, "student"));
+      expect(row.total).toBeGreaterThanOrEqual(1);
+
+      await db.delete(users).where(eq(users.tenantId, tenantNoPlanId));
+    });
+
+    it("sums revenue across all payments", async () => {
+      const [u] = await db
+        .insert(users)
+        .values({
+          name: "Payer",
+          email: `payer-${ts}@test.com`,
+          tenantId: tenantNoPlanId,
+          role: "student",
+        })
+        .returning();
+
+      await db.insert(payments).values({
+        tenantId: tenantNoPlanId,
+        userId: u.id,
+        amount: "49.99",
+      });
+      await db.insert(payments).values({
+        tenantId: tenantNoPlanId,
+        userId: u.id,
+        amount: "10.01",
+      });
+
+      const [row] = await db
+        .select({
+          total: sql<string>`COALESCE(SUM(${payments.amount}), 0)`,
+        })
+        .from(payments)
+        .where(eq(payments.tenantId, tenantNoPlanId));
+      expect(Number(row.total)).toBeCloseTo(60.0, 2);
+
+      await db.delete(payments).where(eq(payments.tenantId, tenantNoPlanId));
+      await db.delete(users).where(eq(users.id, u.id));
+    });
+
+    it("groups tenants by status", async () => {
+      const rows = await db
+        .select({ status: tenants.status, total: count() })
+        .from(tenants)
+        .groupBy(tenants.status);
+
+      const byStatus = Object.fromEntries(rows.map((r) => [r.status, r.total]));
+      expect(byStatus.active ?? 0).toBeGreaterThanOrEqual(3);
+    });
+  });
+});


### PR DESCRIPTION
Adds plan tier configuration, service-layer constraint enforcement, and
a platform metrics dashboard for platform admins (closes #22).

- Plan CRUD server functions (name, max courses/students, fee percent)
- assertCanCreateCourse/assertCanAddStudent helpers; tenants without a
  plan or with null caps are treated as unlimited
- Course creation and Better Auth signup hook now call the enforcement
  helpers to block actions that exceed plan limits
- updateTenantPlanFn + tenant detail UI to reassign plans
- getPlatformMetricsFn aggregating tenant/student/course counts,
  total revenue, and tenants grouped by status
- Platform admin routes: dashboard at /, tenants list, plans
  list/new/edit
- Integration tests cover plan CRUD, course/student enforcement
  (including unlimited plans), fee lookup, plan reassignment and its
  effect on enforcement, and metrics aggregation

https://claude.ai/code/session_01NLNzFQVRF8yTr4Rb8HeySL